### PR TITLE
Find and register Jackson Modules automatically based on classpath.

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
@@ -11,7 +11,7 @@ import java.io.IOException;
  */
 public class JacksonUtil {
 
-    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
     public static <T> T fromString(String string, Class<T> clazz) {
         try {

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
@@ -11,7 +11,7 @@ import java.io.IOException;
  */
 public class JacksonUtil {
 
-    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
     public static <T> T fromString(String string, Class<T> clazz) {
         try {

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
@@ -11,7 +11,7 @@ import java.io.IOException;
  */
 public class JacksonUtil {
 
-    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
     public static <T> T fromString(String string, Class<T> clazz) {
         try {

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
@@ -11,7 +11,7 @@ import java.io.IOException;
  */
 public class JacksonUtil {
 
-    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
     public static <T> T fromString(String string, Class<T> clazz) {
         try {


### PR DESCRIPTION
Should fix issue #3, but it would still be a good idea to expose the 'ObjectMapper' to the user for further customizations.

@vladmihalcea please let me know if you need anything else to merge / deploy this fix as I would really like to start using it from Maven Repos.

Best regards,
Joaquim Pedro