### PR TITLE
Injectable json mapper for type descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,50 @@ hs_err_pid*
 .idea/
 target/
 *.iml
+
+# Eclipse workspace
+.metadata/
+
+# Eclipse Settings directory
+.settings/
+
+# Eclipse Java project classpath
+.classpath
+
+# Eclipse Project file
+.project
+
+# Eclipse PyDev project
+.pydevproject
+
+# Eclipse Checkstyle plugin configuration
+.checkstyle
+
+# Eclipse PMD plugin configuration
+.eclipse-pmd
+.pmd
+
+# Eclipse (R)emote (S)ervers (E)xtensions
+RemoteSystemsTempFiles/
+
+# Eclipse application servers
+Servers/
+
+# Eclipse code recommenders
+.recommenders/
+
+# Eclipse tool builders configurations overrides
+.externalToolBuilders/
+
+# Eclipse Spring Tools Suite
+.springBeans
+
+# Eclipse Java annotation processor (APT)
+.factorypath
+
+# Files open for VI
+*.swp
+
+# IntelliJ workspace
+.idea
+

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/JsonBinaryType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/JsonBinaryType.java
@@ -1,11 +1,14 @@
 package com.vladmihalcea.hibernate.type.json;
 
-import com.vladmihalcea.hibernate.type.json.internal.JsonBinarySqlTypeDescriptor;
-import com.vladmihalcea.hibernate.type.json.internal.JsonTypeDescriptor;
+import java.util.Properties;
+
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.usertype.DynamicParameterizedType;
 
-import java.util.Properties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vladmihalcea.hibernate.type.json.internal.JacksonUtil;
+import com.vladmihalcea.hibernate.type.json.internal.JsonBinarySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.json.internal.JsonTypeDescriptor;
 
 /**
  * Maps any given Java object on a binary JSON column type.
@@ -20,7 +23,11 @@ public class JsonBinaryType
     public static final JsonBinaryType INSTANCE = new JsonBinaryType();
 
     public JsonBinaryType() {
-        super(JsonBinarySqlTypeDescriptor.INSTANCE, new JsonTypeDescriptor());
+    	this(JacksonUtil.OBJECT_MAPPER);
+    }
+
+    public JsonBinaryType(ObjectMapper mapper) {
+        super(JsonBinarySqlTypeDescriptor.INSTANCE, new JsonTypeDescriptor(mapper));
     }
 
     public String getName() {

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/JsonNodeBinaryType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/JsonNodeBinaryType.java
@@ -1,9 +1,11 @@
 package com.vladmihalcea.hibernate.type.json;
 
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vladmihalcea.hibernate.type.json.internal.JsonBinarySqlTypeDescriptor;
 import com.vladmihalcea.hibernate.type.json.internal.JsonNodeTypeDescriptor;
-import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 
 /**
  * Maps a Jackson {@link JsonNode} on a binary JSON column type.
@@ -16,9 +18,13 @@ public class JsonNodeBinaryType
         extends AbstractSingleColumnStandardBasicType<JsonNode> {
 
     public static final JsonNodeBinaryType INSTANCE = new JsonNodeBinaryType();
-    
+
     public JsonNodeBinaryType() {
         super(JsonBinarySqlTypeDescriptor.INSTANCE, JsonNodeTypeDescriptor.INSTANCE);
+    }
+
+    public JsonNodeBinaryType(ObjectMapper mapper) {
+    	super(JsonBinarySqlTypeDescriptor.INSTANCE, new JsonNodeTypeDescriptor(mapper));
     }
 
     public String getName() {

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/JsonStringType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/JsonStringType.java
@@ -1,11 +1,14 @@
 package com.vladmihalcea.hibernate.type.json;
 
-import com.vladmihalcea.hibernate.type.json.internal.JsonStringSqlTypeDescriptor;
-import com.vladmihalcea.hibernate.type.json.internal.JsonTypeDescriptor;
+import java.util.Properties;
+
 import org.hibernate.type.AbstractSingleColumnStandardBasicType;
 import org.hibernate.usertype.DynamicParameterizedType;
 
-import java.util.Properties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vladmihalcea.hibernate.type.json.internal.JacksonUtil;
+import com.vladmihalcea.hibernate.type.json.internal.JsonStringSqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.json.internal.JsonTypeDescriptor;
 
 /**
  * Maps any given Java object on a string-based JSON column type.
@@ -20,7 +23,11 @@ public class JsonStringType
     public static final JsonStringType INSTANCE = new JsonStringType();
 
     public JsonStringType() {
-        super(JsonStringSqlTypeDescriptor.INSTANCE, new JsonTypeDescriptor());
+    	this(JacksonUtil.OBJECT_MAPPER);
+    }
+
+    public JsonStringType(ObjectMapper mapper) {
+        super(JsonStringSqlTypeDescriptor.INSTANCE, new JsonTypeDescriptor(mapper));
     }
 
     public String getName() {

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JacksonUtil.java
@@ -18,40 +18,61 @@ public class JacksonUtil {
     public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
     public static <T> T fromString(String string, Class<T> clazz) {
+        return fromString(OBJECT_MAPPER, string, clazz);
+    }
+
+    public static <T> T fromString(ObjectMapper mapper, String string, Class<T> clazz) {
         try {
-            return OBJECT_MAPPER.readValue(string, clazz);
+            return mapper.readValue(string, clazz);
         } catch (IOException e) {
             throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object", e);
         }
     }
 
     public static <T> T fromString(String string, Type type) {
+        return fromString(OBJECT_MAPPER, string, type);
+    }
+
+    public static <T> T fromString(ObjectMapper mapper, String string, Type type) {
         try {
-            return OBJECT_MAPPER.readValue(string, OBJECT_MAPPER.getTypeFactory().constructType(type));
+            return mapper.readValue(string, OBJECT_MAPPER.getTypeFactory().constructType(type));
         } catch (IOException e) {
             throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object", e);
         }
     }
 
     public static String toString(Object value) {
+        return toString(OBJECT_MAPPER, value);
+    }
+
+    public static String toString(ObjectMapper mapper, Object value) {
         try {
-            return OBJECT_MAPPER.writeValueAsString(value);
+            return mapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String", e);
         }
     }
 
     public static JsonNode toJsonNode(String value) {
+        return toJsonNode(OBJECT_MAPPER, value);
+    }
+
+    public static JsonNode toJsonNode(ObjectMapper mapper, String value) {
         try {
-            return OBJECT_MAPPER.readTree(value);
+            return mapper.readTree(value);
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     public static <T> T clone(T value) {
-        return (value instanceof Serializable) ?
-            (T) SerializationHelper.clone((Serializable) value) :
-                fromString(toString(value), (Class<T>) value.getClass());
+        return clone(OBJECT_MAPPER, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T clone(ObjectMapper mapper, T value) {
+        return (value instanceof Serializable)
+             ? (T) SerializationHelper.clone((Serializable) value)
+             : fromString(mapper, toString(mapper, value), (Class<T>) value.getClass());
     }
 }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonBinarySqlTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonBinarySqlTypeDescriptor.java
@@ -1,14 +1,15 @@
 package com.vladmihalcea.hibernate.type.json.internal;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.sql.BasicBinder;
 
-import java.sql.CallableStatement;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * @author Vlad Mihalcea
@@ -17,8 +18,12 @@ public class JsonBinarySqlTypeDescriptor extends AbstractJsonSqlTypeDescriptor {
 
     public static final JsonBinarySqlTypeDescriptor INSTANCE = new JsonBinarySqlTypeDescriptor();
 
+    public JsonBinarySqlTypeDescriptor() {
+        super();
+    }
+
     @Override
-    public <X> ValueBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+    public <X> ValueBinder<X> getBinder(JavaTypeDescriptor<X> javaTypeDescriptor) {
         return new BasicBinder<X>(javaTypeDescriptor, this) {
             @Override
             protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonNodeTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonNodeTypeDescriptor.java
@@ -1,11 +1,14 @@
 package com.vladmihalcea.hibernate.type.json.internal;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.io.Serializable;
+import java.util.Objects;
+
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
 import org.hibernate.type.descriptor.java.MutableMutabilityPlan;
 
-import java.io.Serializable;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Vlad Mihalcea
@@ -15,24 +18,30 @@ public class JsonNodeTypeDescriptor
 
     public static final JsonNodeTypeDescriptor INSTANCE = new JsonNodeTypeDescriptor();
 
-    public JsonNodeTypeDescriptor() {
-        super(JsonNode.class, new MutableMutabilityPlan<JsonNode>() {
+    protected final ObjectMapper mapperInstance;
 
+    public JsonNodeTypeDescriptor() {
+        this(JacksonUtil.OBJECT_MAPPER);
+    }
+
+    public JsonNodeTypeDescriptor(ObjectMapper mapper) {
+        super(JsonNode.class, new MutableMutabilityPlan<JsonNode>() {
             @Override
             public Serializable disassemble(JsonNode value) {
-                return JacksonUtil.toString(value);
+                return JacksonUtil.toString(mapper, value);
             }
 
             @Override
             public JsonNode assemble(Serializable cached) {
-                return JacksonUtil.toJsonNode((String) cached);
+                return JacksonUtil.toJsonNode(mapper, (String) cached);
             }
 
             @Override
             protected JsonNode deepCopyNotNull(JsonNode value) {
-                return JacksonUtil.clone(value);
+                return JacksonUtil.clone(mapper, value);
             }
         });
+        this.mapperInstance = Objects.requireNonNull(mapper, "No object mapper provided");
     }
 
     @Override
@@ -40,35 +49,45 @@ public class JsonNodeTypeDescriptor
         if (one == another) {
             return true;
         }
-        if (one == null || another == null) {
+
+        if ((one == null) || (another == null)) {
             return false;
         }
-        return JacksonUtil.toJsonNode(JacksonUtil.toString(one)).equals(
-                JacksonUtil.toJsonNode(JacksonUtil.toString(another)));
+
+        String oneString = JacksonUtil.toString(mapperInstance, one);
+        JsonNode oneNode = JacksonUtil.toJsonNode(mapperInstance, oneString);
+        String anotherString = JacksonUtil.toString(mapperInstance, another);
+        JsonNode anotherNode = JacksonUtil.toJsonNode(mapperInstance, anotherString);
+        return Objects.equals(oneNode, anotherNode);
     }
 
     @Override
     public String toString(JsonNode value) {
-        return JacksonUtil.toString(value);
+        return JacksonUtil.toString(mapperInstance, value);
     }
 
     @Override
     public JsonNode fromString(String string) {
-        return JacksonUtil.toJsonNode(string);
+        return JacksonUtil.toJsonNode(mapperInstance, string);
     }
 
-    @SuppressWarnings({"unchecked"})
     @Override
     public <X> X unwrap(JsonNode value, Class<X> type, WrapperOptions options) {
         if (value == null) {
             return null;
         }
+
         if (String.class.isAssignableFrom(type)) {
-            return (X) toString(value);
+            String str = toString(value);
+            return type.cast(str);
         }
+
         if (JsonNode.class.isAssignableFrom(type)) {
-            return (X) JacksonUtil.toJsonNode(toString(value));
+            String str = toString(value);
+            JsonNode node = JacksonUtil.toJsonNode(mapperInstance, str);
+            return type.cast(node);
         }
+
         throw unknownUnwrap(type);
     }
 
@@ -77,7 +96,7 @@ public class JsonNodeTypeDescriptor
         if (value == null) {
             return null;
         }
+
         return fromString(value.toString());
     }
-
 }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonStringSqlTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonStringSqlTypeDescriptor.java
@@ -1,13 +1,13 @@
 package com.vladmihalcea.hibernate.type.json.internal;
 
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 import org.hibernate.type.descriptor.ValueBinder;
 import org.hibernate.type.descriptor.WrapperOptions;
 import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
 import org.hibernate.type.descriptor.sql.BasicBinder;
-
-import java.sql.CallableStatement;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 /**
  * @author Vlad Mihalcea
@@ -15,6 +15,10 @@ import java.sql.SQLException;
 public class JsonStringSqlTypeDescriptor extends AbstractJsonSqlTypeDescriptor {
 
     public static final JsonStringSqlTypeDescriptor INSTANCE = new JsonStringSqlTypeDescriptor();
+
+    public JsonStringSqlTypeDescriptor() {
+    	super();
+    }
 
     @Override
     public <X> ValueBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {


### PR DESCRIPTION
Great project - however, in order to make it more flexible I believe it should allow the users to provide their own _Jackson_ `ObjectMapper` instance just in case the default is not set-up they way they need it. For anyone else the default may be good enough, but it would help (a lot) if users are able to also do the following:

```java
public static final ObjectMapper MY_SUPER_DUPER_OBJECT_MAPPER = ....some special initialization ...

public class MyJsonBinaryType extends JsonBinaryType {
    public MyJsonNodeBinaryType() {
        super(MY_SUPER_DUPER_OBJECT_MAPPER);
    }
}

@TypeDefs({
    @TypeDef(name = "jsonb", typeClass = MyJsonBinaryType.class),
})
@MappedSuperclass
public class MyBaseEntity {
   ...
}
```

**Note**: I made this change only for _Hibernate_ 5.2 since it is the latest one.