### PR TITLE
Use Types.JAVA_OBJECT for AbstractJsonSqlTypeDescriptor, fixes #27

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
@@ -18,7 +18,7 @@ public abstract class AbstractJsonSqlTypeDescriptor implements SqlTypeDescriptor
 
     @Override
     public int getSqlType() {
-        return Types.OTHER;
+        return Types.JAVA_OBJECT;
     }
 
     @Override

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
@@ -18,7 +18,7 @@ public abstract class AbstractJsonSqlTypeDescriptor implements SqlTypeDescriptor
 
     @Override
     public int getSqlType() {
-        return Types.OTHER;
+        return Types.JAVA_OBJECT;
     }
 
     @Override

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
@@ -18,7 +18,7 @@ public abstract class AbstractJsonSqlTypeDescriptor implements SqlTypeDescriptor
 
     @Override
     public int getSqlType() {
-        return Types.OTHER;
+        return Types.JAVA_OBJECT;
     }
 
     @Override

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/AbstractJsonSqlTypeDescriptor.java
@@ -18,7 +18,7 @@ public abstract class AbstractJsonSqlTypeDescriptor implements SqlTypeDescriptor
 
     @Override
     public int getSqlType() {
-        return Types.OTHER;
+        return Types.JAVA_OBJECT;
     }
 
     @Override


### PR DESCRIPTION
Suggested fix for #27 

Use `Types.JAVA_OBJECT` for `AbstractJsonSqlTypeDescriptor`, as it is the JDBC type that Hibernate uses itself in its dialects.