### PR TITLE
Pass cause from ObjectMapper to wrapper clients

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
@@ -41,7 +41,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.readValue(string, clazz);
         } catch (IOException e) {
-            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object");
+            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object", e);
         }
     }
 
@@ -57,7 +57,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String");
+            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String", e);
         }
     }
 

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
@@ -41,7 +41,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.readValue(string, clazz);
         } catch (IOException e) {
-            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object");
+            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object", e);
         }
     }
 
@@ -57,7 +57,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String");
+            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String", e);
         }
     }
 

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
@@ -41,7 +41,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.readValue(string, clazz);
         } catch (IOException e) {
-            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object");
+            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object", e);
         }
     }
 
@@ -57,7 +57,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String");
+            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String", e);
         }
     }
 

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperWrapper.java
@@ -41,7 +41,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.readValue(string, clazz);
         } catch (IOException e) {
-            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object");
+            throw new IllegalArgumentException("The given string value: " + string + " cannot be transformed to Json object", e);
         }
     }
 
@@ -57,7 +57,7 @@ public class ObjectMapperWrapper {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String");
+            throw new IllegalArgumentException("The given Json object value: " + value + " cannot be transformed to a String", e);
         }
     }
 


### PR DESCRIPTION
Otherwise a developer has to debug to discover that e.g. _No serializer found for class ...._ was the actual cause of _The given string value: ... cannot be transformed to Json object_.

Usually you want to know **why** it could not be transformed.