### PR TITLE
Issue #58 add support for enum array type

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.EnumArrayTypeDescriptor;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.util.Properties;
+
+/**
+ * Maps an {@code Enum[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ * <p>
+ * Note that you must set the {@code TYPE_DEF_NAME} and {@code TYPE_DB_NAME} parameters when defining the custom {@code TypeDef}.
+ * The {@code TYPE_DEF_NAME} must equal the same name as the type definition and the {@code TYPE_DB_NAME} must equal the enum type name in PostgreSQL.
+ *
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayType
+        extends AbstractSingleColumnStandardBasicType<Enum[]>
+        implements DynamicParameterizedType {
+
+    public static final EnumArrayType INSTANCE = new EnumArrayType();
+    public static final String TYPE_DEF_NAME = "type_def_name";
+    public static final String TYPE_DB_NAME = "type_db_name";
+    
+    private String typeDefName;
+
+    public EnumArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, EnumArrayTypeDescriptor.INSTANCE);
+    }
+
+    public String getName() {
+        return typeDefName;
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDefName = parameters.getProperty(TYPE_DEF_NAME);
+      ((EnumArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
@@ -1,5 +1,6 @@
 package com.vladmihalcea.hibernate.type.array.internal;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**
@@ -154,6 +155,12 @@ public class ArrayUtil {
                 array[i] = objectArray[i] != null ? (Character) objectArray[i] : 0;
             }
             return (T) array;
+        } else if (Enum[].class.isAssignableFrom(arrayClass)) {
+          T array = arrayClass.cast(Array.newInstance(arrayClass.getComponentType(), objectArray.length));
+          for (int i = 0; i < objectArray.length; i++) {
+              Array.set(array, i, objectArray[i] != null ? Enum.valueOf((Class) arrayClass.getComponentType(), (String) objectArray[i]) : null);
+          }
+          return array;
         } else {
             return (T) objectArray;
         }

--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,0 +1,31 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.Properties;
+
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
+
+/**
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<Enum[]> {
+
+    public static final EnumArrayTypeDescriptor INSTANCE = new EnumArrayTypeDescriptor();
+    
+    private String typeDbName;
+
+    public EnumArrayTypeDescriptor() {
+        super(Enum[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return typeDbName;
+    }
+    
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDbName = parameters.getProperty(EnumArrayType.TYPE_DB_NAME);
+      super.setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
@@ -12,8 +12,14 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.Table;
+import javax.sql.DataSource;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  * @author Vlad Mihalcea
@@ -25,6 +31,48 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         return new Class<?>[]{
                 Event.class,
         };
+    }
+    
+    @Override
+    public void init() {
+      DataSource dataSource = newDataSource();
+      Connection connection = null;
+      try {
+          connection = dataSource.getConnection();
+          Statement statement = null;
+          try {
+              statement = connection.createStatement();
+              try {
+                  statement.executeUpdate(
+                          "DROP TYPE sensor_state CASCADE"
+                  );
+              } catch (SQLException ignore) {
+              }
+              statement.executeUpdate(
+                      "CREATE TYPE sensor_state AS ENUM ('ONLINE', 'OFFLINE', 'UNKNOWN')"
+              );
+          }
+          finally {
+              if (statement != null) {
+                  try {
+                      statement.close();
+                  } catch (SQLException e) {
+                      fail(e.getMessage());
+                  }
+              }
+          }
+      } catch (SQLException e) {
+          fail(e.getMessage());
+      } finally {
+          if (connection != null) {
+              try {
+                  connection.close();
+              } catch (SQLException e) {
+                  fail(e.getMessage());
+              }
+          }
+      }
+      super.init();
     }
 
     @Override
@@ -51,6 +99,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
                 event.setId(1L);
                 event.setSensorNames(new String[]{"Temperature", "Pressure"});
                 event.setSensorValues(new int[]{12, 756});
+                event.setSensorStates(new SensorState[] {SensorState.ONLINE, SensorState.OFFLINE, SensorState.ONLINE, SensorState.UNKNOWN});
                 entityManager.persist(event);
 
                 return null;
@@ -64,6 +113,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
 
                 assertArrayEquals(new String[]{"Temperature", "Pressure"}, event.getSensorNames());
                 assertArrayEquals(new int[]{12, 756}, event.getSensorValues());
+                assertArrayEquals(new SensorState[]{SensorState.ONLINE, SensorState.OFFLINE, SensorState.ONLINE, SensorState.UNKNOWN}, event.getSensorStates());
 
                 return null;
             }
@@ -81,6 +131,10 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Type(type = "int-array")
         @Column(name = "sensor_values", columnDefinition = "integer[]")
         private int[] sensorValues;
+        
+        @Type( type = "sensor-state-array")
+        @Column(name = "sensor_states", columnDefinition = "sensor_state[]")
+        private SensorState[] sensorStates;
 
         public String[] getSensorNames() {
             return sensorNames;
@@ -97,6 +151,18 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         public void setSensorValues(int[] sensorValues) {
             this.sensorValues = sensorValues;
         }
+        
+        public SensorState[] getSensorStates() {
+          return sensorStates;
+        }
+
+        public void setSensorStates(SensorState[] sensorStates) {
+          this.sensorStates = sensorStates;
+        }
+    }
+    
+    public enum SensorState {
+      ONLINE, OFFLINE, UNKNOWN;
     }
 
 }

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -1,9 +1,12 @@
 package com.vladmihalcea.hibernate.type.model;
 
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeStringType;
+
+import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
@@ -17,6 +20,9 @@ import javax.persistence.Version;
 @TypeDefs({
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
+        @TypeDef(name = "sensor-state-array", typeClass = EnumArrayType.class, parameters = {
+            @Parameter(name = EnumArrayType.TYPE_DEF_NAME, value = "sensor-state-array"),
+            @Parameter(name = EnumArrayType.TYPE_DB_NAME, value = "sensor_state")} ),
         @TypeDef(name = "jsonb-node", typeClass = JsonNodeBinaryType.class),
         @TypeDef(name = "json-node", typeClass = JsonNodeStringType.class),
 })

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.EnumArrayTypeDescriptor;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.util.Properties;
+
+/**
+ * Maps an {@code Enum[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ * <p>
+ * Note that you must set the {@code TYPE_DEF_NAME} and {@code TYPE_DB_NAME} parameters when defining the custom {@code TypeDef}.
+ * The {@code TYPE_DEF_NAME} must equal the same name as the type definition and the {@code TYPE_DB_NAME} must equal the enum type name in PostgreSQL.
+ *
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayType
+        extends AbstractSingleColumnStandardBasicType<Enum[]>
+        implements DynamicParameterizedType {
+
+    public static final EnumArrayType INSTANCE = new EnumArrayType();
+    public static final String TYPE_DEF_NAME = "type_def_name";
+    public static final String TYPE_DB_NAME = "type_db_name";
+    
+    private String typeDefName;
+
+    public EnumArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, EnumArrayTypeDescriptor.INSTANCE);
+    }
+
+    public String getName() {
+        return typeDefName;
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDefName = parameters.getProperty(TYPE_DEF_NAME);
+      ((EnumArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
@@ -1,5 +1,6 @@
 package com.vladmihalcea.hibernate.type.array.internal;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**
@@ -154,6 +155,12 @@ public class ArrayUtil {
                 array[i] = objectArray[i] != null ? (Character) objectArray[i] : 0;
             }
             return (T) array;
+        } else if (Enum[].class.isAssignableFrom(arrayClass)) {
+          T array = arrayClass.cast(Array.newInstance(arrayClass.getComponentType(), objectArray.length));
+          for (int i = 0; i < objectArray.length; i++) {
+              Array.set(array, i, objectArray[i] != null ? Enum.valueOf((Class) arrayClass.getComponentType(), (String) objectArray[i]) : null);
+          }
+          return array;
         } else {
             return (T) objectArray;
         }

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,0 +1,31 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.Properties;
+
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
+
+/**
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<Enum[]> {
+
+    public static final EnumArrayTypeDescriptor INSTANCE = new EnumArrayTypeDescriptor();
+    
+    private String typeDbName;
+
+    public EnumArrayTypeDescriptor() {
+        super(Enum[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return typeDbName;
+    }
+    
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDbName = parameters.getProperty(EnumArrayType.TYPE_DB_NAME);
+      super.setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
@@ -12,8 +12,14 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.Table;
+import javax.sql.DataSource;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  * @author Vlad Mihalcea
@@ -25,6 +31,48 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         return new Class<?>[]{
                 Event.class,
         };
+    }
+    
+    @Override
+    public void init() {
+      DataSource dataSource = newDataSource();
+      Connection connection = null;
+      try {
+          connection = dataSource.getConnection();
+          Statement statement = null;
+          try {
+              statement = connection.createStatement();
+              try {
+                  statement.executeUpdate(
+                          "DROP TYPE sensor_state CASCADE"
+                  );
+              } catch (SQLException ignore) {
+              }
+              statement.executeUpdate(
+                      "CREATE TYPE sensor_state AS ENUM ('ONLINE', 'OFFLINE', 'UNKNOWN')"
+              );
+          }
+          finally {
+              if (statement != null) {
+                  try {
+                      statement.close();
+                  } catch (SQLException e) {
+                      fail(e.getMessage());
+                  }
+              }
+          }
+      } catch (SQLException e) {
+          fail(e.getMessage());
+      } finally {
+          if (connection != null) {
+              try {
+                  connection.close();
+              } catch (SQLException e) {
+                  fail(e.getMessage());
+              }
+          }
+      }
+      super.init();
     }
 
     @Override
@@ -51,6 +99,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
                 event.setId(1L);
                 event.setSensorNames(new String[]{"Temperature", "Pressure"});
                 event.setSensorValues(new int[]{12, 756});
+                event.setSensorStates(new SensorState[] {SensorState.ONLINE, SensorState.OFFLINE, SensorState.ONLINE, SensorState.UNKNOWN});
                 entityManager.persist(event);
 
                 return null;
@@ -64,6 +113,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
 
                 assertArrayEquals(new String[]{"Temperature", "Pressure"}, event.getSensorNames());
                 assertArrayEquals(new int[]{12, 756}, event.getSensorValues());
+                assertArrayEquals(new SensorState[]{SensorState.ONLINE, SensorState.OFFLINE, SensorState.ONLINE, SensorState.UNKNOWN}, event.getSensorStates());
 
                 return null;
             }
@@ -81,6 +131,10 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Type(type = "int-array")
         @Column(name = "sensor_values", columnDefinition = "integer[]")
         private int[] sensorValues;
+        
+        @Type( type = "sensor-state-array")
+        @Column(name = "sensor_states", columnDefinition = "sensor_state[]")
+        private SensorState[] sensorStates;
 
         public String[] getSensorNames() {
             return sensorNames;
@@ -97,6 +151,19 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         public void setSensorValues(int[] sensorValues) {
             this.sensorValues = sensorValues;
         }
+        
+        public SensorState[] getSensorStates() {
+          return sensorStates;
+        }
+
+        public void setSensorStates(SensorState[] sensorStates) {
+          this.sensorStates = sensorStates;
+        }
+        
+    }
+    
+    public enum SensorState {
+      ONLINE, OFFLINE, UNKNOWN;
     }
 
 }

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -4,9 +4,11 @@ import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Version;
 
+import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
@@ -20,6 +22,9 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
 @TypeDefs({
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
+        @TypeDef(name = "sensor-state-array", typeClass = EnumArrayType.class, parameters = {
+            @Parameter(name = EnumArrayType.TYPE_DEF_NAME, value = "sensor-state-array"),
+            @Parameter(name = EnumArrayType.TYPE_DB_NAME, value = "sensor_state")} ),
         @TypeDef(name = "json", typeClass = JsonStringType.class),
         @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class),
         @TypeDef(name = "jsonb-node", typeClass = JsonNodeBinaryType.class),

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.EnumArrayTypeDescriptor;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.util.Properties;
+
+/**
+ * Maps an {@code Enum[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ * <p>
+ * Note that you must set the {@code TYPE_DEF_NAME} and {@code TYPE_DB_NAME} parameters when defining the custom {@code TypeDef}.
+ * The {@code TYPE_DEF_NAME} must equal the same name as the type definition and the {@code TYPE_DB_NAME} must equal the enum type name in PostgreSQL.
+ *
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayType
+        extends AbstractSingleColumnStandardBasicType<Enum[]>
+        implements DynamicParameterizedType {
+
+    public static final EnumArrayType INSTANCE = new EnumArrayType();
+    public static final String TYPE_DEF_NAME = "type_def_name";
+    public static final String TYPE_DB_NAME = "type_db_name";
+    
+    private String typeDefName;
+
+    public EnumArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, EnumArrayTypeDescriptor.INSTANCE);
+    }
+
+    public String getName() {
+        return typeDefName;
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDefName = parameters.getProperty(TYPE_DEF_NAME);
+      ((EnumArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
@@ -1,5 +1,6 @@
 package com.vladmihalcea.hibernate.type.array.internal;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**
@@ -154,6 +155,12 @@ public class ArrayUtil {
                 array[i] = objectArray[i] != null ? (Character) objectArray[i] : 0;
             }
             return (T) array;
+        } else if (Enum[].class.isAssignableFrom(arrayClass)) {
+          T array = arrayClass.cast(Array.newInstance(arrayClass.getComponentType(), objectArray.length));
+          for (int i = 0; i < objectArray.length; i++) {
+              Array.set(array, i, objectArray[i] != null ? Enum.valueOf((Class) arrayClass.getComponentType(), (String) objectArray[i]) : null);
+          }
+          return array;
         } else {
             return (T) objectArray;
         }

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,0 +1,31 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.Properties;
+
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
+
+/**
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<Enum[]> {
+
+    public static final EnumArrayTypeDescriptor INSTANCE = new EnumArrayTypeDescriptor();
+    
+    private String typeDbName;
+
+    public EnumArrayTypeDescriptor() {
+        super(Enum[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return typeDbName;
+    }
+    
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDbName = parameters.getProperty(EnumArrayType.TYPE_DB_NAME);
+      super.setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -1,11 +1,14 @@
 package com.vladmihalcea.hibernate.type.model;
 
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeStringType;
 import com.vladmihalcea.hibernate.type.json.JsonStringType;
+
+import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
@@ -19,6 +22,9 @@ import javax.persistence.Version;
 @TypeDefs({
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
+        @TypeDef(name = "sensor-state-array", typeClass = EnumArrayType.class, parameters = {
+            @Parameter(name = EnumArrayType.TYPE_DEF_NAME, value = "sensor-state-array"),
+            @Parameter(name = EnumArrayType.TYPE_DB_NAME, value = "sensor_state")} ),
         @TypeDef(name = "json", typeClass = JsonStringType.class),
         @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class),
         @TypeDef(name = "jsonb-node", typeClass = JsonNodeBinaryType.class),

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.EnumArrayTypeDescriptor;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.util.Properties;
+
+/**
+ * Maps an {@code Enum[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ * <p>
+ * Note that you must set the {@code TYPE_DEF_NAME} and {@code TYPE_DB_NAME} parameters when defining the custom {@code TypeDef}.
+ * The {@code TYPE_DEF_NAME} must equal the same name as the type definition and the {@code TYPE_DB_NAME} must equal the enum type name in PostgreSQL.
+ *
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayType
+        extends AbstractSingleColumnStandardBasicType<Enum[]>
+        implements DynamicParameterizedType {
+
+    public static final EnumArrayType INSTANCE = new EnumArrayType();
+    public static final String TYPE_DEF_NAME = "type_def_name";
+    public static final String TYPE_DB_NAME = "type_db_name";
+    
+    private String typeDefName;
+
+    public EnumArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, EnumArrayTypeDescriptor.INSTANCE);
+    }
+
+    public String getName() {
+        return typeDefName;
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDefName = parameters.getProperty(TYPE_DEF_NAME);
+      ((EnumArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
@@ -1,5 +1,6 @@
 package com.vladmihalcea.hibernate.type.array.internal;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**
@@ -154,6 +155,12 @@ public class ArrayUtil {
                 array[i] = objectArray[i] != null ? (Character) objectArray[i] : 0;
             }
             return (T) array;
+        } else if (Enum[].class.isAssignableFrom(arrayClass)) {
+          T array = arrayClass.cast(Array.newInstance(arrayClass.getComponentType(), objectArray.length));
+          for (int i = 0; i < objectArray.length; i++) {
+              Array.set(array, i, objectArray[i] != null ? Enum.valueOf((Class) arrayClass.getComponentType(), (String) objectArray[i]) : null);
+          }
+          return array;
         } else {
             return (T) objectArray;
         }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,0 +1,31 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.Properties;
+
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
+
+/**
+ * @author Nazir El-Kayssi
+ */
+public class EnumArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<Enum[]> {
+
+    public static final EnumArrayTypeDescriptor INSTANCE = new EnumArrayTypeDescriptor();
+    
+    private String typeDbName;
+
+    public EnumArrayTypeDescriptor() {
+        super(Enum[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return typeDbName;
+    }
+    
+    @Override
+    public void setParameterValues(Properties parameters) {
+      typeDbName = parameters.getProperty(EnumArrayType.TYPE_DB_NAME);
+      super.setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
@@ -10,8 +10,14 @@ import org.junit.Test;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.sql.DataSource;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 
 /**
  * @author Vlad Mihalcea
@@ -24,6 +30,27 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
             Event.class,
         };
     }
+    
+    @Override
+    public void init() {
+      DataSource dataSource = newDataSource();
+      try (Connection connection = dataSource.getConnection()) {
+          try (Statement statement = connection.createStatement()) {
+              try {
+                  statement.executeUpdate(
+                          "DROP TYPE sensor_state CASCADE"
+                  );
+              } catch (SQLException ignore) {
+              }
+              statement.executeUpdate(
+                      "CREATE TYPE sensor_state AS ENUM ('ONLINE', 'OFFLINE', 'UNKNOWN')"
+              );
+          }
+      } catch (SQLException e) {
+          fail(e.getMessage());
+      }
+      super.init();
+  }
 
     @Override
     protected DataSourceProvider dataSourceProvider() {
@@ -46,6 +73,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
             event.setId(1L);
             event.setSensorNames(new String[]{"Temperature", "Pressure"});
             event.setSensorValues(new int[]{12, 756});
+            event.setSensorStates(new SensorState[] {SensorState.ONLINE, SensorState.OFFLINE, SensorState.ONLINE, SensorState.UNKNOWN});
             entityManager.persist(event);
         });
 
@@ -54,6 +82,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
 
             assertArrayEquals(new String[]{"Temperature", "Pressure"}, event.getSensorNames());
             assertArrayEquals(new int[]{12, 756}, event.getSensorValues());
+            assertArrayEquals(new SensorState[]{SensorState.ONLINE, SensorState.OFFLINE, SensorState.ONLINE, SensorState.UNKNOWN}, event.getSensorStates());
         });
     }
 
@@ -68,6 +97,10 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Type(type = "int-array")
         @Column(name = "sensor_values", columnDefinition = "integer[]")
         private int[] sensorValues;
+        
+        @Type( type = "sensor-state-array")
+        @Column(name = "sensor_states", columnDefinition = "sensor_state[]")
+        private SensorState[] sensorStates;
 
         public String[] getSensorNames() {
             return sensorNames;
@@ -84,6 +117,19 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         public void setSensorValues(int[] sensorValues) {
             this.sensorValues = sensorValues;
         }
+
+        public SensorState[] getSensorStates() {
+          return sensorStates;
+        }
+
+        public void setSensorStates(SensorState[] sensorStates) {
+          this.sensorStates = sensorStates;
+        }
+        
+    }
+    
+    public enum SensorState {
+      ONLINE, OFFLINE, UNKNOWN;
     }
 
 }

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -1,11 +1,14 @@
 package com.vladmihalcea.hibernate.type.model;
 
+import com.vladmihalcea.hibernate.type.array.EnumArrayType;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeStringType;
 import com.vladmihalcea.hibernate.type.json.JsonStringType;
+
+import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
@@ -19,6 +22,9 @@ import javax.persistence.Version;
 @TypeDefs({
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
+        @TypeDef(name = "sensor-state-array", typeClass = EnumArrayType.class, parameters = {
+            @Parameter(name = EnumArrayType.TYPE_DEF_NAME, value = "sensor-state-array"),
+            @Parameter(name = EnumArrayType.TYPE_DB_NAME, value = "sensor_state")} ),
         @TypeDef(name = "json", typeClass = JsonStringType.class),
         @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class),
         @TypeDef(name = "jsonb-node", typeClass = JsonNodeBinaryType.class),


### PR DESCRIPTION
These changes will allow Hibernate to map enum arrays in Java to an enum typed array in PostgreSQL. The unwrapArray method in the ArrayUtil class was updated to handle java enum arrays. No changes were required to the wrapArray method since Hibernate by default will convert enum arrays to string arrays when inserting into PostgreSQL, which is the intended functionality. A new EnumArrayType was added that requires two extra parameters to be passed when using the TypeDef annotation. These parameters are used to define the enum name in Java and the enum type name in PostgreSQL. This means that you will need a separate TypeDef for each enum array type used.