### PR TITLE
Issue with ZoneDateTime when valid milliseconds is less than 4 or less decimal places

### DIFF
--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/ZonedDateTimeMilliSecondTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/ZonedDateTimeMilliSecondTest.java
@@ -1,0 +1,91 @@
+package com.vladmihalcea.hibernate.type.range;
+
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import static com.vladmihalcea.hibernate.type.range.Range.zonedDateTimeRange;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Arun Mohandas
+ */
+public class ZonedDateTimeMilliSecondTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[] {
+            Restriction.class
+        };
+    }
+
+    @Test
+    public void success() {
+        validateTest(zonedDateTimeRange("[\"2018-05-03T10:15:30.127110+12:00\",\"2018-12-03T10:15:30.127111+12:00\"]"));
+    }
+
+    @Test
+    public void failForZoneDateTimeWithOnly4OrLessValidDecimalForMilliSecond() {
+        validateTest(zonedDateTimeRange("[\"2018-05-03T10:15:30.127100+12:00\",\"2018-12-03T10:15:30.127111+12:00\"]"));
+        validateTest(zonedDateTimeRange("[\"2018-05-03T10:15:30.127000+12:00\",\"2018-12-03T10:15:30.127111+12:00\"]"));
+    }
+
+    private void validateTest(Range<ZonedDateTime> tsTz) {
+        doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            restriction.setId(1L);
+            restriction.setRangeZonedDateTime(tsTz);
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, 1L);
+
+            ZoneId zone = ar.getRangeZonedDateTime().lower().getZone();
+
+            ZonedDateTime lower = tsTz.lower().withZoneSameInstant(zone);
+
+            assertEquals(lower, ar.getRangeZonedDateTime().lower());
+            assertEquals(LocalDateTime.parse("2018-12-03T10:15:30").atZone(ZoneId.systemDefault()).getOffset(),
+                ar.getRangeZonedDateTime().upper().getOffset());
+        });
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    @TypeDef(name = "range", typeClass = PostgreSQLRangeType.class, defaultForType = Range.class)
+    public static class Restriction {
+
+        @Id
+        private Long id;
+
+        @Column(name = "r_tstzrange", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTime;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTime() {
+            return rangeZonedDateTime;
+        }
+
+        public void setRangeZonedDateTime(Range<ZonedDateTime> rangeZonedDateTime) {
+            this.rangeZonedDateTime = rangeZonedDateTime;
+        }
+    }
+}


### PR DESCRIPTION
Hi there,
Great project!
Wanted to highlight a problem I have faced while using this for tstzrange.

For tstzrange, if the ZoneDateTime creation has valid milliseconds less than 4 or less decimal places, retrieval from db fails for the persisted records.

Sample dateTime values which gives error:
"2018-05-03T10:15:30.127100+12:00"
""2018-05-03T10:15:30.127000+12:00"

Even though  ZONE_DATE_TIME has format "yyyy-MM-dd HH:mm:ss[.SSSSSS]X"), while persisting to postgres it ignores trailing zeros.
Retrieval of record fails during formating this.
Eg:
"java.time.format.DateTimeParseException: Text '2018-05-03 00:15:30.1271+02' could not be parsed at index 10"

Sample test case added in the pull request. Please review.