### PR TITLE
Add PostgreSQL TSVector type 

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -2,7 +2,7 @@ package com.vladmihalcea.hibernate.type.basic;
 
 import com.vladmihalcea.hibernate.type.ImmutableType;
 import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -15,7 +15,7 @@ import java.sql.Types;
  * @author Vlad Mihalcea
  * @author Philip Riecks
  */
-public class PostgreSQLTSVectorType  extends ImmutableType<String> {
+public class PostgreSQLTSVectorType extends ImmutableType<String> {
 
     public PostgreSQLTSVectorType() {
         super(String.class);
@@ -27,13 +27,13 @@ public class PostgreSQLTSVectorType  extends ImmutableType<String> {
     }
 
     @Override
-    protected String get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner)
             throws SQLException {
         return rs.getString(names[0]);
     }
 
     @Override
-    protected void set(PreparedStatement st, String value, int index, SharedSessionContractImplementor session)
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session)
             throws SQLException {
         if (value == null) {
             st.setNull(index, Types.OTHER);

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -2,7 +2,7 @@ package com.vladmihalcea.hibernate.type.basic;
 
 import com.vladmihalcea.hibernate.type.ImmutableType;
 import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -15,7 +15,7 @@ import java.sql.Types;
  * @author Vlad Mihalcea
  * @author Philip Riecks
  */
-public class PostgreSQLTSVectorType  extends ImmutableType<String> {
+public class PostgreSQLTSVectorType extends ImmutableType<String> {
 
     public PostgreSQLTSVectorType() {
         super(String.class);
@@ -27,13 +27,13 @@ public class PostgreSQLTSVectorType  extends ImmutableType<String> {
     }
 
     @Override
-    protected String get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner)
             throws SQLException {
         return rs.getString(names[0]);
     }
 
     @Override
-    protected void set(PreparedStatement st, String value, int index, SharedSessionContractImplementor session)
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session)
             throws SQLException {
         if (value == null) {
             st.setNull(index, Types.OTHER);

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -2,7 +2,7 @@ package com.vladmihalcea.hibernate.type.basic;
 
 import com.vladmihalcea.hibernate.type.ImmutableType;
 import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -15,7 +15,7 @@ import java.sql.Types;
  * @author Vlad Mihalcea
  * @author Philip Riecks
  */
-public class PostgreSQLTSVectorType  extends ImmutableType<String> {
+public class PostgreSQLTSVectorType extends ImmutableType<String> {
 
     public PostgreSQLTSVectorType() {
         super(String.class);
@@ -27,13 +27,13 @@ public class PostgreSQLTSVectorType  extends ImmutableType<String> {
     }
 
     @Override
-    protected String get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner)
             throws SQLException {
         return rs.getString(names[0]);
     }
 
     @Override
-    protected void set(PreparedStatement st, String value, int index, SharedSessionContractImplementor session)
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session)
             throws SQLException {
         if (value == null) {
             st.setNull(index, Types.OTHER);

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -1,13 +1,11 @@
 package com.vladmihalcea.hibernate.type.basic;
 
-import com.vladmihalcea.hibernate.type.ImmutableType;
-import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import com.vladmihalcea.hibernate.type.basic.internal.PostgreSQLTSVectorSqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.basic.internal.PostgreSQLTSVectorTypeDescriptor;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
+import java.util.Properties;
 
 /**
  * Maps a {@link String} object type to a PostgreSQL TSVector column type.
@@ -15,33 +13,23 @@ import java.sql.Types;
  * @author Vlad Mihalcea
  * @author Philip Riecks
  */
-public class PostgreSQLTSVectorType  extends ImmutableType<String> {
+public class PostgreSQLTSVectorType
+        extends AbstractSingleColumnStandardBasicType<String> implements DynamicParameterizedType {
+
+    public static final PostgreSQLTSVectorType INSTANCE = new PostgreSQLTSVectorType();
+
 
     public PostgreSQLTSVectorType() {
-        super(String.class);
+        super(PostgreSQLTSVectorSqlTypeDescriptor.INSTANCE,  new PostgreSQLTSVectorTypeDescriptor());
     }
 
     @Override
-    public int[] sqlTypes() {
-        return new int[] { Types.OTHER };
+    public String getName() {
+        return "tsvector";
     }
 
     @Override
-    protected String get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
-            throws SQLException {
-        return rs.getString(names[0]);
-    }
-
-    @Override
-    protected void set(PreparedStatement st, String value, int index, SharedSessionContractImplementor session)
-            throws SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
-            ReflectionUtils.invokeSetter(holder, "type", "tsvector");
-            ReflectionUtils.invokeSetter(holder, "value", value);
-            st.setObject(index, holder);
-        }
+    public void setParameterValues(Properties parameters) {
+        ((PostgreSQLTSVectorTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
     }
 }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -1,0 +1,41 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class PostgreSQLTSVectorType  extends ImmutableType<String> {
+
+    public PostgreSQLTSVectorType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[] { Types.OTHER };
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+            throws SQLException {
+        return rs.getString(names[0]);
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SharedSessionContractImplementor session)
+            throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", "tsvector");
+            ReflectionUtils.invokeSetter(holder, "value", value);
+            st.setObject(index, holder);
+        }
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/PostgreSQLTSVectorSqlTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/PostgreSQLTSVectorSqlTypeDescriptor.java
@@ -1,0 +1,33 @@
+package com.vladmihalcea.hibernate.type.basic.internal;
+
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
+
+import java.sql.Types;
+
+public class PostgreSQLTSVectorSqlTypeDescriptor implements SqlTypeDescriptor {
+
+    public static final PostgreSQLTSVectorSqlTypeDescriptor INSTANCE = new PostgreSQLTSVectorSqlTypeDescriptor();
+
+    @Override
+    public int getSqlType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public boolean canBeRemapped() {
+        return false;
+    }
+
+    @Override
+    public <X> ValueBinder<X> getBinder(JavaTypeDescriptor<X> javaTypeDescriptor) {
+        return null;
+    }
+
+    @Override
+    public <X> ValueExtractor<X> getExtractor(JavaTypeDescriptor<X> javaTypeDescriptor) {
+        return null;
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/PostgreSQLTSVectorTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/PostgreSQLTSVectorTypeDescriptor.java
@@ -1,0 +1,34 @@
+package com.vladmihalcea.hibernate.type.basic.internal;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.util.Properties;
+
+public class PostgreSQLTSVectorTypeDescriptor extends AbstractTypeDescriptor<String> implements DynamicParameterizedType {
+
+    public PostgreSQLTSVectorTypeDescriptor() {
+        super(String.class);
+    }
+
+    @Override
+    public String fromString(String string) {
+        return null;
+    }
+
+    @Override
+    public <X> X unwrap(String value, Class<X> type, WrapperOptions options) {
+        return null;
+    }
+
+    @Override
+    public <X> String wrap(X value, WrapperOptions options) {
+        return null;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorTypeTest.java
@@ -1,0 +1,98 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[] {
+                Book.class
+        };
+    }
+
+    @Override
+    public void afterInit() {
+        doInJDBC(connection -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.executeUpdate("INSERT INTO book (id, isbn, text) VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', to_tsvector('This book" +
+                        " is a journey into Java data access performance tuning. From connection management, to batch" +
+                        " updates, fetch sizes and concurrency control mechanisms, it unravels the inner workings of" +
+                        " the most common Java data access frameworks'))");
+            } catch (SQLException e) {
+                fail(e.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+            Book book = entityManager.find(Book.class, 1L);
+
+            assertTrue(book.getText().contains(":"));
+            assertTrue(book.getText().contains("'"));
+            assertTrue(book.getText().contains("java"));
+            assertTrue(book.getText().contains("size"));
+            assertTrue(book.getText().contains("access"));
+            assertTrue(book.getText().contains("batch"));
+            assertTrue(book.getText().contains("book"));
+        });
+    }
+
+    @Entity(name = "Book")
+    @Table(name = "book")
+    @TypeDef(name = "tsvector", typeClass = PostgreSQLTSVectorType.class, defaultForType = String.class)
+    public static class Book {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @NaturalId
+        private String isbn;
+
+        @Type(type = "tsvector")
+        @Column(columnDefinition = "tsvector")
+        private String text;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getIsbn() {
+            return isbn;
+        }
+
+        public void setIsbn(String isbn) {
+            this.isbn = isbn;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+    }
+}


### PR DESCRIPTION
I've added PostgreSQL `TSVector` data type with a Java `String` representation. Please have a look at the test (https://github.com/vladmihalcea/hibernate-types/pull/91/commits/67bef47a7b2411d100492df1f62e5a1a4189dabe)  for the new type. I would add the missing tests to the other `hibernate-typesXY` folder if the test is okay. 