### PR TITLE
Add ZoneIdType to map the java.time.ZoneId to a VARCHAR-based column

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/ZoneIdType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/ZoneIdType.java
@@ -1,0 +1,30 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.basic.internal.ZoneIdTypeDescriptor;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.sql.VarcharTypeDescriptor;
+
+import java.time.ZoneId;
+
+/**
+ * Maps a Java {@link ZoneId} object to an {@code VARCHAR} column type.
+ *
+ */
+public class ZoneIdType extends AbstractSingleColumnStandardBasicType<ZoneId> {
+
+    public static final ZoneIdType INSTANCE = new ZoneIdType();
+
+    public ZoneIdType() {
+        super(VarcharTypeDescriptor.INSTANCE, ZoneIdTypeDescriptor.INSTANCE);
+    }
+
+    @Override
+    public String getName() {
+        return "zone-id";
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/ZoneIdTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/ZoneIdTypeDescriptor.java
@@ -1,0 +1,63 @@
+package com.vladmihalcea.hibernate.type.basic.internal;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+
+import java.time.ZoneId;
+import java.util.Comparator;
+
+/**
+ * Descriptor for {@link ZoneId} handling.
+ *
+ * @see org.hibernate.type.descriptor.java.TimeZoneTypeDescriptor
+ */
+public class ZoneIdTypeDescriptor extends AbstractTypeDescriptor<ZoneId> {
+
+    public static final ZoneIdTypeDescriptor INSTANCE = new ZoneIdTypeDescriptor();
+
+    public static class ZoneIdComparator implements Comparator<ZoneId> {
+        public static final ZoneIdComparator INSTANCE = new ZoneIdComparator();
+
+        public int compare(ZoneId o1, ZoneId o2) {
+            return o1.getId().compareTo(o2.getId());
+        }
+    }
+
+    public ZoneIdTypeDescriptor() {
+        super(ZoneId.class);
+    }
+
+    public String toString(ZoneId value) {
+        return value.getId();
+    }
+
+    public ZoneId fromString(String string) {
+        return ZoneId.of(string);
+    }
+
+    @Override
+    public Comparator<ZoneId> getComparator() {
+        return ZoneIdComparator.INSTANCE;
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    public <X> X unwrap(ZoneId value, Class<X> type, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        if (String.class.isAssignableFrom(type)) {
+            return (X) toString(value);
+        }
+        throw unknownUnwrap(type);
+    }
+
+    public <X> ZoneId wrap(X value, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        if (String.class.isInstance(value)) {
+            return fromString((String) value);
+        }
+        throw unknownWrap(value.getClass());
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/ZoneIdTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/ZoneIdTest.java
@@ -1,0 +1,94 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.util.AbstractMySQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import org.hibernate.Session;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.time.ZoneId;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@see ZoneId} Hibernate mapping.
+ */
+public class ZoneIdTest extends AbstractMySQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{UserPreferences.class};
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+            UserPreferences UserPreferences = new UserPreferences();
+            UserPreferences.setName("vladmihalcea.com");
+            UserPreferences.setZoneId(ZoneId.of("Europe/Bucharest"));
+
+            entityManager.persist(UserPreferences);
+        });
+
+        doInJPA(entityManager -> {
+            UserPreferences userPreferences = entityManager.unwrap(Session.class)
+                    .bySimpleNaturalId(UserPreferences.class).load("vladmihalcea.com");
+
+            assertEquals(ZoneId.of("Europe/Bucharest"), userPreferences.getZoneId());
+        });
+
+        doInJPA(entityManager -> {
+            UserPreferences prefs = entityManager
+                    .createQuery("select p " +
+                            "from UserPreferences p " +
+                            "where " +
+                            " p.zoneId = :zoneId", UserPreferences.class)
+                    .setParameter("zoneId", ZoneId.of("Europe/Bucharest"))
+                    .getSingleResult();
+
+            assertEquals("vladmihalcea.com", prefs.getName());
+        });
+    }
+
+    @Entity(name = "UserPreferences")
+    @Table(name = "user_preferences")
+    @TypeDef(typeClass = ZoneIdType.class, defaultForType = ZoneId.class)
+    public static class UserPreferences {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @NaturalId
+        private String name;
+
+       @Column(name = "zone_id", length= 40)
+        private ZoneId zoneId;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public ZoneId getZoneId() {
+            return zoneId;
+        }
+
+        public void setZoneId(ZoneId zoneId) {
+            this.zoneId = zoneId;
+        }
+    }
+}


### PR DESCRIPTION
I suggest to add **`ZoneIdType`** to map Java class `java.time.ZoneId` as SQL type `VARCHAR`.

Tested with MySQL 5.

## Explanations

- Hibernate 5 maps type `java.util.TimeZone`  as SQL type `VARCHAR` (see `org.hibernate.type.TimeZoneType`).
- Hibernate 5  maps type `java.time.ZoneId`  as SQL type `TINYBLOB` by default. Use **`ZoneIdType`** to map SQL type `VARCHAR`.

resolves #102.