### PR TITLE
Add PostgreSQL UUID ARRAY support

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
@@ -1,0 +1,42 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import java.util.Properties;
+import java.util.UUID;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.UUIDArrayTypeDescriptor;
+
+/**
+ * Maps an {@code UUID[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayType
+        extends AbstractSingleColumnStandardBasicType<UUID[]>
+        implements DynamicParameterizedType {
+
+    public static final UUIDArrayType INSTANCE = new UUIDArrayType();
+
+    public UUIDArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, new UUIDArrayTypeDescriptor());
+    }
+
+    public String getName() {
+        return "uuid-array";
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+        ((UUIDArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
@@ -1,0 +1,19 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.UUID;
+
+/**
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<UUID[]> {
+
+    public UUIDArrayTypeDescriptor() {
+        super(UUID[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return "uuid";
+    }
+}

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.UUID;
 
 /**
  * @author Vlad Mihalcea
@@ -52,6 +53,9 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
               }
               statement.executeUpdate(
                       "CREATE TYPE sensor_state AS ENUM ('ONLINE', 'OFFLINE', 'UNKNOWN')"
+              );
+              statement.executeUpdate(
+                  "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
               );
           }
           finally {
@@ -99,6 +103,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
 
                 Event event = new Event();
                 event.setId(1L);
+                event.setSensorIds(new UUID[]{UUID.fromString("c65a3bcb-8b36-46d4-bddb-ae96ad016eb1"), UUID.fromString("72e95717-5294-4c15-aa64-a3631cf9a800")});
                 event.setSensorNames(new String[]{"Temperature", "Pressure"});
                 event.setSensorValues(new int[]{12, 756});
                 event.setSensorLongValues(new long[]{42L, 9223372036854775800L});
@@ -114,6 +119,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
             public Void apply(EntityManager entityManager) {
                 Event event = entityManager.find(Event.class, 1L);
 
+                assertArrayEquals(new UUID[]{UUID.fromString("c65a3bcb-8b36-46d4-bddb-ae96ad016eb1"), UUID.fromString("72e95717-5294-4c15-aa64-a3631cf9a800")}, event.getSensorIds());
                 assertArrayEquals(new String[]{"Temperature", "Pressure"}, event.getSensorNames());
                 assertArrayEquals(new int[]{12, 756}, event.getSensorValues());
                 assertArrayEquals(new long[]{42L, 9223372036854775800L}, event.getSensorLongValues());
@@ -130,6 +136,9 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Parameter(name = EnumArrayType.SQL_ARRAY_TYPE, value = "sensor_state")}
     )
     public static class Event extends BaseEntity {
+        @Type(type = "uuid-array")
+        @Column(name = "sensor_ids", columnDefinition = "uuid[]")
+        private UUID[] sensorIds;
 
         @Type(type = "string-array")
         @Column(name = "sensor_names", columnDefinition = "text[]")
@@ -146,6 +155,14 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Type( type = "sensor-state-array")
         @Column(name = "sensor_states", columnDefinition = "sensor_state[]")
         private SensorState[] sensorStates;
+
+        public UUID[] getSensorIds() {
+            return sensorIds;
+        }
+
+        public void setSensorIds(UUID[] sensorIds) {
+            this.sensorIds = sensorIds;
+        }
 
         public String[] getSensorNames() {
             return sensorNames;

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -1,13 +1,12 @@
 package com.vladmihalcea.hibernate.type.model;
 
-import com.vladmihalcea.hibernate.type.array.EnumArrayType;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.LongArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
+import com.vladmihalcea.hibernate.type.array.UUIDArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeStringType;
 
-import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
@@ -19,6 +18,7 @@ import javax.persistence.Version;
  * @author Vlad Mihalcea
  */
 @TypeDefs({
+        @TypeDef(name = "uuid-array", typeClass = UUIDArrayType.class),
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
         @TypeDef(name = "long-array", typeClass = LongArrayType.class),

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
@@ -1,0 +1,42 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import java.util.Properties;
+import java.util.UUID;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.UUIDArrayTypeDescriptor;
+
+/**
+ * Maps an {@code UUID[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayType
+        extends AbstractSingleColumnStandardBasicType<UUID[]>
+        implements DynamicParameterizedType {
+
+    public static final UUIDArrayType INSTANCE = new UUIDArrayType();
+
+    public UUIDArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, new UUIDArrayTypeDescriptor());
+    }
+
+    public String getName() {
+        return "uuid-array";
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+        ((UUIDArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
@@ -1,0 +1,19 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.UUID;
+
+/**
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<UUID[]> {
+
+    public UUIDArrayTypeDescriptor() {
+        super(UUID[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return "uuid";
+    }
+}

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.UUID;
 
 /**
  * @author Vlad Mihalcea
@@ -52,6 +53,9 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
               }
               statement.executeUpdate(
                       "CREATE TYPE sensor_state AS ENUM ('ONLINE', 'OFFLINE', 'UNKNOWN')"
+              );
+              statement.executeUpdate(
+                  "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
               );
           }
           finally {
@@ -99,6 +103,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
 
                 Event event = new Event();
                 event.setId(1L);
+                event.setSensorIds(new UUID[]{UUID.fromString("c65a3bcb-8b36-46d4-bddb-ae96ad016eb1"), UUID.fromString("72e95717-5294-4c15-aa64-a3631cf9a800")});
                 event.setSensorNames(new String[]{"Temperature", "Pressure"});
                 event.setSensorValues(new int[]{12, 756});
                 event.setSensorLongValues(new long[]{42L, 9223372036854775800L});
@@ -114,6 +119,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
             public Void apply(EntityManager entityManager) {
                 Event event = entityManager.find(Event.class, 1L);
 
+                assertArrayEquals(new UUID[]{UUID.fromString("c65a3bcb-8b36-46d4-bddb-ae96ad016eb1"), UUID.fromString("72e95717-5294-4c15-aa64-a3631cf9a800")}, event.getSensorIds());
                 assertArrayEquals(new String[]{"Temperature", "Pressure"}, event.getSensorNames());
                 assertArrayEquals(new int[]{12, 756}, event.getSensorValues());
                 assertArrayEquals(new long[]{42L, 9223372036854775800L}, event.getSensorLongValues());
@@ -130,6 +136,9 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Parameter(name = EnumArrayType.SQL_ARRAY_TYPE, value = "sensor_state")}
     )
     public static class Event extends BaseEntity {
+        @Type(type = "uuid-array")
+        @Column(name = "sensor_ids", columnDefinition = "uuid[]")
+        private UUID[] sensorIds;
 
         @Type(type = "string-array")
         @Column(name = "sensor_names", columnDefinition = "text[]")
@@ -146,6 +155,14 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Type( type = "sensor-state-array")
         @Column(name = "sensor_states", columnDefinition = "sensor_state[]")
         private SensorState[] sensorStates;
+
+        public UUID[] getSensorIds() {
+            return sensorIds;
+        }
+
+        public void setSensorIds(UUID[] sensorIds) {
+            this.sensorIds = sensorIds;
+        }
 
         public String[] getSensorNames() {
             return sensorNames;

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.TypeDefs;
 import com.vladmihalcea.hibernate.type.array.EnumArrayType;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
+import com.vladmihalcea.hibernate.type.array.UUIDArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeStringType;
@@ -21,6 +22,7 @@ import com.vladmihalcea.hibernate.type.json.JsonStringType;
  * @author Vlad Mihalcea
  */
 @TypeDefs({
+        @TypeDef(name = "uuid-array", typeClass = UUIDArrayType.class),
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
         @TypeDef(name = "long-array", typeClass = LongArrayType.class),

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
@@ -1,0 +1,42 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import java.util.Properties;
+import java.util.UUID;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.UUIDArrayTypeDescriptor;
+
+/**
+ * Maps an {@code UUID[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayType
+        extends AbstractSingleColumnStandardBasicType<UUID[]>
+        implements DynamicParameterizedType {
+
+    public static final UUIDArrayType INSTANCE = new UUIDArrayType();
+
+    public UUIDArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, new UUIDArrayTypeDescriptor());
+    }
+
+    public String getName() {
+        return "uuid-array";
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+        ((UUIDArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
@@ -1,0 +1,19 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.UUID;
+
+/**
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<UUID[]> {
+
+    public UUIDArrayTypeDescriptor() {
+        super(UUID[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return "uuid";
+    }
+}

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/array/ArrayTypeTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.UUID;
 
 /**
  * @author Vlad Mihalcea
@@ -52,6 +53,9 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
               }
               statement.executeUpdate(
                       "CREATE TYPE sensor_state AS ENUM ('ONLINE', 'OFFLINE', 'UNKNOWN')"
+              );
+              statement.executeUpdate(
+                  "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
               );
           }
           finally {
@@ -99,6 +103,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
 
                 Event event = new Event();
                 event.setId(1L);
+                event.setSensorIds(new UUID[]{UUID.fromString("c65a3bcb-8b36-46d4-bddb-ae96ad016eb1"), UUID.fromString("72e95717-5294-4c15-aa64-a3631cf9a800")});
                 event.setSensorNames(new String[]{"Temperature", "Pressure"});
                 event.setSensorValues(new int[]{12, 756});
                 event.setSensorLongValues(new long[]{42L, 9223372036854775800L});
@@ -114,6 +119,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
             public Void apply(EntityManager entityManager) {
                 Event event = entityManager.find(Event.class, 1L);
 
+                assertArrayEquals(new UUID[]{UUID.fromString("c65a3bcb-8b36-46d4-bddb-ae96ad016eb1"), UUID.fromString("72e95717-5294-4c15-aa64-a3631cf9a800")}, event.getSensorIds());
                 assertArrayEquals(new String[]{"Temperature", "Pressure"}, event.getSensorNames());
                 assertArrayEquals(new int[]{12, 756}, event.getSensorValues());
                 assertArrayEquals(new long[]{42L, 9223372036854775800L}, event.getSensorLongValues());
@@ -130,6 +136,9 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Parameter(name = EnumArrayType.SQL_ARRAY_TYPE, value = "sensor_state")}
     )
     public static class Event extends BaseEntity {
+        @Type(type = "uuid-array")
+        @Column(name = "sensor_ids", columnDefinition = "uuid[]")
+        private UUID[] sensorIds;
 
         @Type(type = "string-array")
         @Column(name = "sensor_names", columnDefinition = "text[]")
@@ -147,6 +156,14 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
         @Column(name = "sensor_states", columnDefinition = "sensor_state[]")
         private SensorState[] sensorStates;
 
+        public UUID[] getSensorIds() {
+            return sensorIds;
+        }
+
+        public void setSensorIds(UUID[] sensorIds) {
+            this.sensorIds = sensorIds;
+        }
+
         public String[] getSensorNames() {
             return sensorNames;
         }
@@ -155,7 +172,7 @@ public class ArrayTypeTest extends AbstractPostgreSQLIntegrationTest {
             this.sensorNames = sensorNames;
         }
 
-    public int[] getSensorValues() {
+        public int[] getSensorValues() {
             return sensorValues;
         }
 

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -1,15 +1,14 @@
 package com.vladmihalcea.hibernate.type.model;
 
-import com.vladmihalcea.hibernate.type.array.EnumArrayType;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.LongArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
+import com.vladmihalcea.hibernate.type.array.UUIDArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeStringType;
 import com.vladmihalcea.hibernate.type.json.JsonStringType;
 
-import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
@@ -21,6 +20,7 @@ import javax.persistence.Version;
  * @author Vlad Mihalcea
  */
 @TypeDefs({
+        @TypeDef(name = "uuid-array", typeClass = UUIDArrayType.class),
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
         @TypeDef(name = "long-array", typeClass = LongArrayType.class),

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/UUIDArrayType.java
@@ -1,0 +1,43 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import java.util.Properties;
+import java.util.UUID;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.StringArrayTypeDescriptor;
+import com.vladmihalcea.hibernate.type.array.internal.UUIDArrayTypeDescriptor;
+
+/**
+ * Maps an {@code UUID[]} array on a PostgreSQL ARRAY type.
+ * <p>
+ * For more details about how to use it, check out <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayType
+        extends AbstractSingleColumnStandardBasicType<UUID[]>
+        implements DynamicParameterizedType {
+
+    public static final UUIDArrayType INSTANCE = new UUIDArrayType();
+
+    public UUIDArrayType() {
+        super(ArraySqlTypeDescriptor.INSTANCE, new UUIDArrayTypeDescriptor());
+    }
+
+    public String getName() {
+        return "uuid-array";
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+        ((UUIDArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/UUIDArrayTypeDescriptor.java
@@ -1,0 +1,19 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+import java.util.UUID;
+
+/**
+ * @author Rafael Acevedo
+ */
+public class UUIDArrayTypeDescriptor
+        extends AbstractArrayTypeDescriptor<UUID[]> {
+
+    public UUIDArrayTypeDescriptor() {
+        super(UUID[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return "uuid";
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -3,6 +3,7 @@ package com.vladmihalcea.hibernate.type.model;
 import com.vladmihalcea.hibernate.type.array.IntArrayType;
 import com.vladmihalcea.hibernate.type.array.LongArrayType;
 import com.vladmihalcea.hibernate.type.array.StringArrayType;
+import com.vladmihalcea.hibernate.type.array.UUIDArrayType;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType;
 import com.vladmihalcea.hibernate.type.json.JsonNodeStringType;
@@ -18,6 +19,7 @@ import javax.persistence.Version;
  * @author Vlad Mihalcea
  */
 @TypeDefs({
+        @TypeDef(name = "uuid-array", typeClass = UUIDArrayType.class),
         @TypeDef(name = "string-array", typeClass = StringArrayType.class),
         @TypeDef(name = "int-array", typeClass = IntArrayType.class),
         @TypeDef(name = "long-array", typeClass = LongArrayType.class),


### PR DESCRIPTION
This PR adds support for postgres uuid array types. Initially, it only covers `hibernate-types-52`. If the approach is good, I will replicate to the other hibernate versions.