### PR TITLE
Add handling for null PostgreSQL Range column values

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
@@ -48,6 +48,9 @@ public class PostgreSQLRangeType extends ImmutableType<Range> {
     @Override
     protected Range get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner) throws SQLException {
         PGobject pgObject = (PGobject) rs.getObject(names[0]);
+        if (pgObject == null) {
+            return null;
+        }
         String type = pgObject.getType();
         String value = pgObject.getValue();
 

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeTypeTest.java
@@ -14,6 +14,7 @@ import java.time.ZonedDateTime;
 import static com.vladmihalcea.hibernate.type.range.Range.infinite;
 import static com.vladmihalcea.hibernate.type.range.Range.zonedDateTimeRange;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Edgar Asatryan
@@ -71,6 +72,27 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
             ZonedDateTime upper = tsTz.upper().withZoneSameInstant(zone);
 
             assertEquals(ar.getRangeZonedDateTime(), Range.closed(lower, upper));
+        });
+    }
+
+    @Test
+    public void testNullable() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertNull(ar.getRangeInt());
+            assertNull(ar.getRangeLong());
+            assertNull(ar.getRangeBigDecimal());
+            assertNull(ar.getLocalDateTimeRange());
+            assertNull(ar.getLocalDateRange());
+            assertNull(ar.getRangeZonedDateTime());
         });
     }
 


### PR DESCRIPTION
It appears that NPE throws while getting null ranges from a table. PR tries to handle this situation. 