### PR TITLE
Type implementation for PostgreSQL interval, fixes #53

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/interval/PostgreSQLIntervalType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/interval/PostgreSQLIntervalType.java
@@ -1,0 +1,65 @@
+package com.vladmihalcea.hibernate.type.interval;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.postgresql.util.PGInterval;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Maps an {@link Duration} object type to a PostgreSQL Interval column type.
+ * <p>
+ *
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLIntervalType extends ImmutableType<Duration> {
+
+    public static final PostgreSQLIntervalType INSTANCE = new PostgreSQLIntervalType();
+
+    public PostgreSQLIntervalType() {
+        super(Duration.class);
+    }
+
+    @Override
+    protected Duration get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        final PGInterval pgi = (PGInterval) rs.getObject(names[0]);
+
+        if (pgi == null) {
+            return null;
+        }
+
+        final int days = pgi.getDays();
+        final int hours = pgi.getHours();
+        final int mins = pgi.getMinutes();
+        final double secs = pgi.getSeconds();
+
+        return Duration.ofDays(days)
+            .plus(hours, ChronoUnit.HOURS)
+            .plus(mins, ChronoUnit.MINUTES)
+            .plus((long) Math.floor(secs), ChronoUnit.SECONDS);
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Duration value, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            final int days = (int) value.toDays();
+            final int hours = (int) (value.toHours() % 24);
+            final int mins = (int) (value.toMinutes() % 60);
+            final double secs = value.getSeconds() % 60;
+            st.setObject(index, new PGInterval(0, 0, days, hours, mins, secs));
+        }
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[] { Types.OTHER };
+    }
+
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/interval/PostgreSQLIntervalTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/interval/PostgreSQLIntervalTypeTest.java
@@ -1,0 +1,53 @@
+package com.vladmihalcea.hibernate.type.interval;
+
+import com.vladmihalcea.hibernate.type.model.BaseEntity;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import java.time.Duration;
+
+public class PostgreSQLIntervalTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[] { IntervalEntity.class };
+    }
+
+    @Test
+    public void test() {
+        doInJPA(em -> {
+            IntervalEntity intervalEntity = new IntervalEntity();
+            intervalEntity.setId(1L);
+            Duration duration = Duration.ofDays(1).plusHours(2).plusMinutes(3).plusSeconds(4);
+            intervalEntity.setInterval(duration);
+            em.persist(intervalEntity);
+            em.flush();
+            em.clear();
+
+            IntervalEntity result = em.createQuery("SELECT a from IntervalEntity a", IntervalEntity.class).getSingleResult();
+            Assert.assertEquals(duration, result.getInterval());
+        });
+    }
+
+    @Entity(name = "IntervalEntity")
+    @TypeDef(name = "interval", typeClass = PostgreSQLIntervalType.class, defaultForType = Duration.class)
+    public static class IntervalEntity extends BaseEntity {
+
+        @Type(type = "interval")
+        @Column(columnDefinition = "interval")
+        private Duration interval;
+
+        public Duration getInterval() {
+            return interval;
+        }
+
+        public void setInterval(Duration interval) {
+            this.interval = interval;
+        }
+    }
+}


### PR DESCRIPTION
Implements a custom type for the PostgreSQL Interval type, and maps it to a Java 8 Duration (see also: https://github.com/vladmihalcea/hibernate-types/issues/53).

Notes:
- Only implemented in `hibernate-types-52` due to the dependency on Java 8
- Nanos are not considered because the value would lose precision in the long to float conversion anyway