### PR TITLE
Add support for PostgreSQL tx_vector column type

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -1,0 +1,47 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link String} object type to a PostgreSQL TSVector column type.
+ *
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorType extends ImmutableType<String> {
+
+    public PostgreSQLTSVectorType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[] { Types.OTHER };
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner)
+            throws SQLException {
+        return rs.getString(names[0]);
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session)
+            throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", "tsvector");
+            ReflectionUtils.invokeSetter(holder, "value", value);
+            st.setObject(index, holder);
+        }
+    }
+}

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
@@ -1,0 +1,103 @@
+package com.vladmihalcea.hibernate.type.search;
+
+import com.vladmihalcea.hibernate.type.basic.PostgreSQLTSVectorType;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+            Book.class
+        };
+    }
+
+    @Test
+    public void test() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book book = new Book();
+                book.setId(1L);
+                book.setIsbn("978-9730228236");
+                book.setFts(
+                    "This book is a journey into Java data access performance tuning. From connection management, to batch" +
+                        " updates, fetch sizes and concurrency control mechanisms, it unravels the inner workings of" +
+                        " the most common Java data access frameworks."
+                );
+
+                entityManager.persist(book);
+
+                return null;
+            }
+        });
+
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book book = entityManager.find(Book.class, 1L);
+
+                assertTrue(book.getFts().contains("Java"));
+                assertTrue(book.getFts().contains("concurrency"));
+                assertTrue(book.getFts().contains("book"));
+
+                return null;
+            }
+        });
+    }
+
+    @Entity(name = "Book")
+    @Table(name = "book")
+    @TypeDef(name = "tsvector", typeClass = PostgreSQLTSVectorType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        @NaturalId
+        private String isbn;
+
+        @Type(type = "tsvector")
+        @Column(columnDefinition = "tsvector")
+        private String fts;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getIsbn() {
+            return isbn;
+        }
+
+        public void setIsbn(String isbn) {
+            this.isbn = isbn;
+        }
+
+        public String getFts() {
+            return fts;
+        }
+
+        public void setFts(String fts) {
+            this.fts = fts;
+        }
+    }
+}

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -1,0 +1,47 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link String} object type to a PostgreSQL TSVector column type.
+ *
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorType extends ImmutableType<String> {
+
+    public PostgreSQLTSVectorType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[] { Types.OTHER };
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner)
+            throws SQLException {
+        return rs.getString(names[0]);
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session)
+            throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", "tsvector");
+            ReflectionUtils.invokeSetter(holder, "value", value);
+            st.setObject(index, holder);
+        }
+    }
+}

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
@@ -1,0 +1,103 @@
+package com.vladmihalcea.hibernate.type.search;
+
+import com.vladmihalcea.hibernate.type.basic.PostgreSQLTSVectorType;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+            Book.class
+        };
+    }
+
+    @Test
+    public void test() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book book = new Book();
+                book.setId(1L);
+                book.setIsbn("978-9730228236");
+                book.setFts(
+                    "This book is a journey into Java data access performance tuning. From connection management, to batch" +
+                        " updates, fetch sizes and concurrency control mechanisms, it unravels the inner workings of" +
+                        " the most common Java data access frameworks."
+                );
+
+                entityManager.persist(book);
+
+                return null;
+            }
+        });
+
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book book = entityManager.find(Book.class, 1L);
+
+                assertTrue(book.getFts().contains("Java"));
+                assertTrue(book.getFts().contains("concurrency"));
+                assertTrue(book.getFts().contains("book"));
+
+                return null;
+            }
+        });
+    }
+
+    @Entity(name = "Book")
+    @Table(name = "book")
+    @TypeDef(name = "tsvector", typeClass = PostgreSQLTSVectorType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        @NaturalId
+        private String isbn;
+
+        @Type(type = "tsvector")
+        @Column(columnDefinition = "tsvector")
+        private String fts;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getIsbn() {
+            return isbn;
+        }
+
+        public void setIsbn(String isbn) {
+            this.isbn = isbn;
+        }
+
+        public String getFts() {
+            return fts;
+        }
+
+        public void setFts(String fts) {
+            this.fts = fts;
+        }
+    }
+}

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLTSVectorType.java
@@ -1,0 +1,47 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link String} object type to a PostgreSQL TSVector column type.
+ *
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorType extends ImmutableType<String> {
+
+    public PostgreSQLTSVectorType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[] { Types.OTHER };
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner)
+            throws SQLException {
+        return rs.getString(names[0]);
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session)
+            throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", "tsvector");
+            ReflectionUtils.invokeSetter(holder, "value", value);
+            st.setObject(index, holder);
+        }
+    }
+}

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
@@ -1,0 +1,103 @@
+package com.vladmihalcea.hibernate.type.search;
+
+import com.vladmihalcea.hibernate.type.basic.PostgreSQLTSVectorType;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+            Book.class
+        };
+    }
+
+    @Test
+    public void test() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book book = new Book();
+                book.setId(1L);
+                book.setIsbn("978-9730228236");
+                book.setFts(
+                    "This book is a journey into Java data access performance tuning. From connection management, to batch" +
+                        " updates, fetch sizes and concurrency control mechanisms, it unravels the inner workings of" +
+                        " the most common Java data access frameworks."
+                );
+
+                entityManager.persist(book);
+
+                return null;
+            }
+        });
+
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book book = entityManager.find(Book.class, 1L);
+
+                assertTrue(book.getFts().contains("Java"));
+                assertTrue(book.getFts().contains("concurrency"));
+                assertTrue(book.getFts().contains("book"));
+
+                return null;
+            }
+        });
+    }
+
+    @Entity(name = "Book")
+    @Table(name = "book")
+    @TypeDef(name = "tsvector", typeClass = PostgreSQLTSVectorType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        @NaturalId
+        private String isbn;
+
+        @Type(type = "tsvector")
+        @Column(columnDefinition = "tsvector")
+        private String fts;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getIsbn() {
+            return isbn;
+        }
+
+        public void setIsbn(String isbn) {
+            this.isbn = isbn;
+        }
+
+        public String getFts() {
+            return fts;
+        }
+
+        public void setFts(String fts) {
+            this.fts = fts;
+        }
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorType.java
@@ -1,0 +1,35 @@
+package com.vladmihalcea.hibernate.type.search;
+
+import com.vladmihalcea.hibernate.type.search.internal.PostgreSQLTSVectorSqlTypeDescriptor;
+import com.vladmihalcea.hibernate.type.search.internal.PostgreSQLTSVectorTypeDescriptor;
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.util.Properties;
+
+/**
+ * Maps a {@link String} object type to a PostgreSQL TSVector column type.
+ *
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorType
+        extends AbstractSingleColumnStandardBasicType<Object> implements DynamicParameterizedType {
+
+    public static final PostgreSQLTSVectorType INSTANCE = new PostgreSQLTSVectorType();
+
+
+    public PostgreSQLTSVectorType() {
+        super(PostgreSQLTSVectorSqlTypeDescriptor.INSTANCE, new PostgreSQLTSVectorTypeDescriptor());
+    }
+
+    @Override
+    public String getName() {
+        return "tsvector";
+    }
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+        ((PostgreSQLTSVectorTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorSqlTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorSqlTypeDescriptor.java
@@ -1,0 +1,70 @@
+package com.vladmihalcea.hibernate.type.search.internal;
+
+import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
+import org.hibernate.type.descriptor.ValueBinder;
+import org.hibernate.type.descriptor.ValueExtractor;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.JavaTypeDescriptor;
+import org.hibernate.type.descriptor.sql.BasicBinder;
+import org.hibernate.type.descriptor.sql.BasicExtractor;
+import org.hibernate.type.descriptor.sql.SqlTypeDescriptor;
+
+import java.sql.*;
+
+public class PostgreSQLTSVectorSqlTypeDescriptor implements SqlTypeDescriptor {
+
+    public static final PostgreSQLTSVectorSqlTypeDescriptor INSTANCE = new PostgreSQLTSVectorSqlTypeDescriptor();
+
+    @Override
+    public int getSqlType() {
+        return Types.OTHER;
+    }
+
+    @Override
+    public boolean canBeRemapped() {
+        return false;
+    }
+
+    @Override
+    public <X> ValueBinder<X> getBinder(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+        return new BasicBinder<X>(javaTypeDescriptor, this) {
+            @Override
+            protected void doBind(PreparedStatement st, X value, int index, WrapperOptions options) throws SQLException {
+                Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+                ReflectionUtils.invokeSetter(holder, "type", "tsvector");
+                ReflectionUtils.invokeSetter(holder, "value", javaTypeDescriptor.unwrap(value, String.class, options));
+                st.setObject(index, holder);
+            }
+
+            @Override
+            protected void doBind(CallableStatement st, X value, String name, WrapperOptions options)
+                    throws SQLException {
+                Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+                ReflectionUtils.invokeSetter(holder, "type", "tsvector");
+                ReflectionUtils.invokeSetter(holder, "value", javaTypeDescriptor.unwrap(value, String.class, options));
+
+                st.setObject(name, holder);
+            }
+        };
+    }
+
+    @Override
+    public <X> ValueExtractor<X> getExtractor(final JavaTypeDescriptor<X> javaTypeDescriptor) {
+        return new BasicExtractor<X>(javaTypeDescriptor, this) {
+            @Override
+            protected X doExtract(ResultSet rs, String name, WrapperOptions options) throws SQLException {
+                return javaTypeDescriptor.wrap(rs.getString( name ), options);
+            }
+
+            @Override
+            protected X doExtract(CallableStatement statement, int index, WrapperOptions options) throws SQLException {
+                return javaTypeDescriptor.wrap(statement.getString(index), options);
+            }
+
+            @Override
+            protected X doExtract(CallableStatement statement, String name, WrapperOptions options) throws SQLException {
+                return javaTypeDescriptor.wrap(statement.getString(name), options);
+            }
+        };
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
@@ -1,0 +1,89 @@
+package com.vladmihalcea.hibernate.type.search.internal;
+
+import com.vladmihalcea.hibernate.type.util.ReflectionUtils;
+import com.vladmihalcea.hibernate.type.util.StringUtils;
+import org.hibernate.annotations.common.reflection.XProperty;
+import org.hibernate.annotations.common.reflection.java.JavaXMember;
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Properties;
+
+public class PostgreSQLTSVectorTypeDescriptor extends AbstractTypeDescriptor<Object> implements DynamicParameterizedType {
+
+    public PostgreSQLTSVectorTypeDescriptor() {
+        super(Object.class);
+    }
+
+    private Type type;
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+        final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
+        if (xProperty instanceof JavaXMember) {
+            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+        } else {
+            type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
+        }
+    }
+
+    @Override
+    public boolean areEqual(Object one, Object another) {
+        if (one == another) {
+            return true;
+        }
+        if (one == null || another == null) {
+            return false;
+        }
+        if (one instanceof String && another instanceof String) {
+            return one.equals(another);
+        }
+        return one.equals(another);
+    }
+
+    @Override
+    public String toString(Object value) {
+        return value.toString();
+    }
+
+    @Override
+    public Object fromString(String string) {
+        if (String.class.isAssignableFrom(typeToClass())) {
+            return string;
+        }
+        return string;
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public <X> X unwrap(Object value, Class<X> type, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        if (String.class.isAssignableFrom(type)) {
+            return (X) toString(value);
+        }
+        throw unknownUnwrap(type);
+    }
+
+    @Override
+    public <X> Object wrap(X value, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        return fromString(value.toString());
+    }
+
+    private Class typeToClass() {
+        Type classType = type;
+        if (type instanceof ParameterizedType) {
+            classType = ((ParameterizedType) type).getRawType();
+        }
+        return (Class) classType;
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/search/PostgreSQLTSVectorTypeTest.java
@@ -1,0 +1,92 @@
+package com.vladmihalcea.hibernate.type.search;
+
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Vlad Mihalcea
+ * @author Philip Riecks
+ */
+public class PostgreSQLTSVectorTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+            Book.class
+        };
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+            Book book = new Book();
+            book.setId(1L);
+            book.setIsbn("978-9730228236");
+            book.setFts(
+                "This book is a journey into Java data access performance tuning. From connection management, to batch" +
+                    " updates, fetch sizes and concurrency control mechanisms, it unravels the inner workings of" +
+                    " the most common Java data access frameworks."
+            );
+
+            entityManager.persist(book);
+        });
+
+        doInJPA(entityManager -> {
+            Book book = entityManager.find(Book.class, 1L);
+
+            assertTrue(book.getFts().contains("Java"));
+            assertTrue(book.getFts().contains("concurrency"));
+            assertTrue(book.getFts().contains("book"));
+        });
+    }
+
+    @Entity(name = "Book")
+    @Table(name = "book")
+    @TypeDef(name = "tsvector", typeClass = PostgreSQLTSVectorType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        @NaturalId
+        private String isbn;
+
+        @Type(type = "tsvector")
+        @Column(columnDefinition = "tsvector")
+        private String fts;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getIsbn() {
+            return isbn;
+        }
+
+        public void setIsbn(String isbn) {
+            this.isbn = isbn;
+        }
+
+        public String getFts() {
+            return fts;
+        }
+
+        public void setFts(String fts) {
+            this.fts = fts;
+        }
+    }
+}


### PR DESCRIPTION
This PR supersedes the [original work](https://github.com/vladmihalcea/hibernate-types/pull/91) done by @rieckpil.

However, having a Hibernate Type is not as powerful as just using a TRIGGER that populates the ts_vector column by calling `to_tsvector`. The current implementation only casts the provided String to a `ts_vector` type which lacks the integer positions of the associated lexemes.