### PR TITLE
Remove unnecessary null checks and PGobject instantiations

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
@@ -43,10 +43,6 @@ public class PostgreSQLEnumType extends org.hibernate.type.EnumType {
             int index,
             SessionImplementor session)
             throws HibernateException, SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            st.setObject(index, value.toString(), Types.OTHER);
-        }
+        st.setObject(index, value == null ? null : value.toString(), Types.OTHER);
     }
 }

--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
@@ -42,14 +42,6 @@ public class PostgreSQLHStoreType extends ImmutableType<Map> {
 
     @Override
     protected void set(PreparedStatement st, Map value, int index, SessionImplementor session) throws SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            PGobject holder = new PGobject();
-            holder.setType("hstore");
-            holder.setValue(HStoreConverter.toString(value));
-
-            st.setObject(index, holder);
-        }
+        st.setObject(index, value);
     }
 }

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
@@ -43,10 +43,6 @@ public class PostgreSQLEnumType extends org.hibernate.type.EnumType {
             int index,
             SessionImplementor session)
             throws HibernateException, SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            st.setObject(index, value.toString(), Types.OTHER);
-        }
+        st.setObject(index, value, Types.OTHER);
     }
 }

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
@@ -42,14 +42,6 @@ public class PostgreSQLHStoreType extends ImmutableType<Map> {
 
     @Override
     protected void set(PreparedStatement st, Map value, int index, SessionImplementor session) throws SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            PGobject holder = new PGobject();
-            holder.setType("hstore");
-            holder.setValue(HStoreConverter.toString(value));
-
-            st.setObject(index, holder);
-        }
+        st.setObject(index, value);
     }
 }

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
@@ -43,10 +43,6 @@ public class PostgreSQLEnumType extends org.hibernate.type.EnumType {
             int index,
             SessionImplementor session)
             throws HibernateException, SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            st.setObject(index, value.toString(), Types.OTHER);
-        }
+        st.setObject(index, value, Types.OTHER);
     }
 }

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
@@ -42,14 +42,6 @@ public class PostgreSQLHStoreType extends ImmutableType<Map> {
 
     @Override
     protected void set(PreparedStatement st, Map value, int index, SessionImplementor session) throws SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            PGobject holder = new PGobject();
-            holder.setType("hstore");
-            holder.setValue(HStoreConverter.toString(value));
-
-            st.setObject(index, holder);
-        }
+        st.setObject(index, value);
     }
 }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
@@ -43,10 +43,6 @@ public class PostgreSQLEnumType extends org.hibernate.type.EnumType {
             int index,
             SharedSessionContractImplementor session)
             throws HibernateException, SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            st.setObject(index, value.toString(), Types.OTHER);
-        }
+        st.setObject(index, value, Types.OTHER);
     }
 }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreType.java
@@ -42,14 +42,7 @@ public class PostgreSQLHStoreType extends ImmutableType<Map> {
 
     @Override
     protected void set(PreparedStatement st, Map value, int index, SharedSessionContractImplementor session) throws SQLException {
-        if (value == null) {
-            st.setNull(index, Types.OTHER);
-        } else {
-            PGobject holder = new PGobject();
-            holder.setType("hstore");
-            holder.setValue(HStoreConverter.toString(value));
+        st.setObject(index, value);
 
-            st.setObject(index, holder);
-        }
     }
 }


### PR DESCRIPTION
This PR removes  unnecessary null checks and pgobject object creation when statement setObject method used because it all for us made in pg jdbc. Also it's improve hstore mapping - setObject made it too.