### PR TITLE
Adds support of NonNullStringType

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link String} object to an SQL <code>VARCHAR</code> or <code>LONGVARCHAR</code> value,
+ * avoiding two possible values for “no data” by replacing NULLs with blank lines.
+ * Usually string-based fields have two possible values for “no data”: NULL, and the empty (blank) string.
+ * In most cases, it’s redundant and can lead to mistakes.
+ *
+ * @author Andrei Akinchev
+ */
+public class NonNullStringType extends ImmutableType<String> {
+
+    public static final NonNullStringType INSTANCE = new NonNullStringType();
+
+    public NonNullStringType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws SQLException {
+        String value = rs.getString(names[0]);
+        if (value == null) {
+            return "";
+        }
+        return value;
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session) throws SQLException {
+        if (value == null) {
+            value = "";
+        }
+        st.setString(index, value);
+    }
+}

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
@@ -1,0 +1,167 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.ConnectionVoidCallable;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Andrei Akinchev
+ */
+public class NonNullStringTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Book.class
+        };
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                try {
+                    statement = connection.createStatement();
+
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (1, 'a', 'a')");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (2, 'b', NULL)");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (3, 'c', '')");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testSelect() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookA = entityManager.find(Book.class, 1L);
+                assertEquals(bookA.getDescription(), "a");
+
+                Book bookB = entityManager.find(Book.class, 2L);
+                assertEquals(bookB.getDescription(), "");
+
+                Book bookC = entityManager.find(Book.class, 3L);
+                assertEquals(bookC.getDescription(), "");
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testInsert() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookD = new Book();
+                bookD.setId(4L);
+                bookD.setTitle("d");
+                bookD.setDescription("d");
+                entityManager.persist(bookD);
+
+                Book bookE = new Book();
+                bookE.setId(5L);
+                bookE.setTitle("e");
+                bookE.setDescription(null);
+                entityManager.persist(bookE);
+
+                Book bookF = new Book();
+                bookF.setId(6L);
+                bookF.setTitle("b");
+                bookF.setDescription("");
+                entityManager.persist(bookF);
+
+                return null;
+            }
+        });
+
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                ResultSet resultSet = null;
+                try {
+                    statement = connection.createStatement();
+                    resultSet = statement.executeQuery("SELECT description FROM books WHERE id IN (4, 5, 6) ORDER BY id");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "d");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (resultSet != null) {
+                        resultSet.close();
+                    }
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Table(name = "books")
+    @Entity(name = "Book")
+    @TypeDef(name = "non_null_string", typeClass = NonNullStringType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        private String title;
+
+        @Type(type = "non_null_string")
+        @Column(columnDefinition = "varchar")
+        private String description;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link String} object to an SQL <code>VARCHAR</code> or <code>LONGVARCHAR</code> value,
+ * avoiding two possible values for “no data” by replacing NULLs with blank lines.
+ * Usually string-based fields have two possible values for “no data”: NULL, and the empty (blank) string.
+ * In most cases, it’s redundant and can lead to mistakes.
+ *
+ * @author Andrei Akinchev
+ */
+public class NonNullStringType extends ImmutableType<String> {
+
+    public static final NonNullStringType INSTANCE = new NonNullStringType();
+
+    public NonNullStringType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws SQLException {
+        String value = rs.getString(names[0]);
+        if (value == null) {
+            return "";
+        }
+        return value;
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session) throws SQLException {
+        if (value == null) {
+            value = "";
+        }
+        st.setString(index, value);
+    }
+}

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
@@ -1,0 +1,168 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.ConnectionVoidCallable;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Andrei Akinchev
+ */
+public class NonNullStringTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Book.class
+        };
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                try {
+                    statement = connection.createStatement();
+
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (1, 'a', 'a')");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (2, 'b', NULL)");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (3, 'c', '')");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testSelect() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookA = entityManager.find(Book.class, 1L);
+                assertEquals(bookA.getDescription(), "a");
+
+                Book bookB = entityManager.find(Book.class, 2L);
+                assertEquals(bookB.getDescription(), "");
+
+                Book bookC = entityManager.find(Book.class, 3L);
+                assertEquals(bookC.getDescription(), "");
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testInsert() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookD = new Book();
+                bookD.setId(4L);
+                bookD.setTitle("d");
+                bookD.setDescription("d");
+                entityManager.persist(bookD);
+
+                Book bookE = new Book();
+                bookE.setId(5L);
+                bookE.setTitle("e");
+                bookE.setDescription(null);
+                entityManager.persist(bookE);
+
+                Book bookF = new Book();
+                bookF.setId(6L);
+                bookF.setTitle("b");
+                bookF.setDescription("");
+                entityManager.persist(bookF);
+
+                return null;
+            }
+        });
+
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                ResultSet resultSet = null;
+                try {
+                    statement = connection.createStatement();
+                    resultSet = statement.executeQuery("SELECT description FROM books WHERE id IN (4, 5, 6) ORDER BY id");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "d");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (resultSet != null) {
+                        resultSet.close();
+                    }
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Table(name = "books")
+    @Entity(name = "Book")
+    @TypeDef(name = "non_null_string", typeClass = NonNullStringType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        private String title;
+
+        @Type(type = "non_null_string")
+        @Column(columnDefinition = "varchar")
+        private String description;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link String} object to an SQL <code>VARCHAR</code> or <code>LONGVARCHAR</code> value,
+ * avoiding two possible values for “no data” by replacing NULLs with blank lines.
+ * Usually string-based fields have two possible values for “no data”: NULL, and the empty (blank) string.
+ * In most cases, it’s redundant and can lead to mistakes.
+ *
+ * @author Andrei Akinchev
+ */
+public class NonNullStringType extends ImmutableType<String> {
+
+    public static final NonNullStringType INSTANCE = new NonNullStringType();
+
+    public NonNullStringType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws SQLException {
+        String value = rs.getString(names[0]);
+        if (value == null) {
+            return "";
+        }
+        return value;
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SessionImplementor session) throws SQLException {
+        if (value == null) {
+            value = "";
+        }
+        st.setString(index, value);
+    }
+}

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
@@ -1,0 +1,168 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.ConnectionVoidCallable;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Andrei Akinchev
+ */
+public class NonNullStringTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Book.class
+        };
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                try {
+                    statement = connection.createStatement();
+
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (1, 'a', 'a')");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (2, 'b', NULL)");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (3, 'c', '')");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testSelect() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookA = entityManager.find(Book.class, 1L);
+                assertEquals(bookA.getDescription(), "a");
+
+                Book bookB = entityManager.find(Book.class, 2L);
+                assertEquals(bookB.getDescription(), "");
+
+                Book bookC = entityManager.find(Book.class, 3L);
+                assertEquals(bookC.getDescription(), "");
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testInsert() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookD = new Book();
+                bookD.setId(4L);
+                bookD.setTitle("d");
+                bookD.setDescription("d");
+                entityManager.persist(bookD);
+
+                Book bookE = new Book();
+                bookE.setId(5L);
+                bookE.setTitle("e");
+                bookE.setDescription(null);
+                entityManager.persist(bookE);
+
+                Book bookF = new Book();
+                bookF.setId(6L);
+                bookF.setTitle("b");
+                bookF.setDescription("");
+                entityManager.persist(bookF);
+
+                return null;
+            }
+        });
+
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                ResultSet resultSet = null;
+                try {
+                    statement = connection.createStatement();
+                    resultSet = statement.executeQuery("SELECT description FROM books WHERE id IN (4, 5, 6) ORDER BY id");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "d");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (resultSet != null) {
+                        resultSet.close();
+                    }
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Table(name = "books")
+    @Entity(name = "Book")
+    @TypeDef(name = "non_null_string", typeClass = NonNullStringType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        private String title;
+
+        @Type(type = "non_null_string")
+        @Column(columnDefinition = "varchar")
+        private String description;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/NonNullStringType.java
@@ -1,0 +1,48 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link String} object to an SQL <code>VARCHAR</code> or <code>LONGVARCHAR</code> value,
+ * avoiding two possible values for “no data” by replacing NULLs with blank lines.
+ * Usually string-based fields have two possible values for “no data”: NULL, and the empty (blank) string.
+ * In most cases, it’s redundant and can lead to mistakes.
+ *
+ * @author Andrei Akinchev
+ */
+public class NonNullStringType extends ImmutableType<String> {
+
+    public static final NonNullStringType INSTANCE = new NonNullStringType();
+
+    public NonNullStringType() {
+        super(String.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected String get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        String value = rs.getString(names[0]);
+        if (value == null) {
+            return "";
+        }
+        return value;
+    }
+
+    @Override
+    protected void set(PreparedStatement st, String value, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (value == null) {
+            value = "";
+        }
+        st.setString(index, value);
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/NonNullStringTypeTest.java
@@ -1,0 +1,168 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.ConnectionVoidCallable;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Andrei Akinchev
+ */
+public class NonNullStringTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Book.class
+        };
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                try {
+                    statement = connection.createStatement();
+
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (1, 'a', 'a')");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (2, 'b', NULL)");
+                    statement.executeUpdate("INSERT INTO books (id, title, description) VALUES (3, 'c', '')");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testSelect() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookA = entityManager.find(Book.class, 1L);
+                assertEquals(bookA.getDescription(), "a");
+
+                Book bookB = entityManager.find(Book.class, 2L);
+                assertEquals(bookB.getDescription(), "");
+
+                Book bookC = entityManager.find(Book.class, 3L);
+                assertEquals(bookC.getDescription(), "");
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testInsert() {
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Book bookD = new Book();
+                bookD.setId(4L);
+                bookD.setTitle("d");
+                bookD.setDescription("d");
+                entityManager.persist(bookD);
+
+                Book bookE = new Book();
+                bookE.setId(5L);
+                bookE.setTitle("e");
+                bookE.setDescription(null);
+                entityManager.persist(bookE);
+
+                Book bookF = new Book();
+                bookF.setId(6L);
+                bookF.setTitle("b");
+                bookF.setDescription("");
+                entityManager.persist(bookF);
+
+                return null;
+            }
+        });
+
+        doInJDBC(new ConnectionVoidCallable() {
+            @Override
+            public void execute(Connection connection) throws SQLException {
+                Statement statement = null;
+                ResultSet resultSet = null;
+                try {
+                    statement = connection.createStatement();
+                    resultSet = statement.executeQuery("SELECT description FROM books WHERE id IN (4, 5, 6) ORDER BY id");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "d");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                    resultSet.next();
+                    assertEquals(resultSet.getString(1), "");
+                } catch (SQLException e) {
+                    fail(e.getMessage());
+                } finally {
+                    if (resultSet != null) {
+                        resultSet.close();
+                    }
+                    if (statement != null) {
+                        statement.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Table(name = "books")
+    @Entity(name = "Book")
+    @TypeDef(name = "non_null_string", typeClass = NonNullStringType.class)
+    public static class Book {
+
+        @Id
+        private Long id;
+
+        private String title;
+
+        @Type(type = "non_null_string")
+        @Column(columnDefinition = "varchar")
+        private String description;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+}


### PR DESCRIPTION
Usually string-based fields have two possible values for “no data”: NULL, and the empty (blank) string.
In most cases, it’s redundant and can lead to mistakes.
This PR adds support for NonNullStringType, which helps to avoid two possible values for “no data” by replacing NULLs with blank lines.