### PR TITLE
Ability to use PostgreSQLEnumType and EnumArrayType with TypedParameterValue

### DIFF
--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
@@ -4,6 +4,7 @@ import com.vladmihalcea.hibernate.type.AbstractHibernateType;
 import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
 import com.vladmihalcea.hibernate.type.array.internal.EnumArrayTypeDescriptor;
 import com.vladmihalcea.hibernate.type.util.Configuration;
+import com.vladmihalcea.hibernate.type.util.ParameterizedParameterType;
 import org.hibernate.annotations.Type;
 import org.hibernate.usertype.DynamicParameterizedType;
 
@@ -41,6 +42,14 @@ public class EnumArrayType
             new EnumArrayTypeDescriptor(),
             configuration
         );
+    }
+
+    public EnumArrayType(Class<? extends Enum> enumClass, String sqlArrayType) {
+        this();
+        Properties parameters = new Properties();
+        parameters.setProperty(SQL_ARRAY_TYPE, sqlArrayType);
+        parameters.put(DynamicParameterizedType.PARAMETER_TYPE, new ParameterizedParameterType(enumClass));
+        setParameterValues(parameters);
     }
 
     public String getName() {

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ParameterizedParameterType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ParameterizedParameterType.java
@@ -1,0 +1,55 @@
+package com.vladmihalcea.hibernate.type.util;
+
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A stub {@code ParameterType} that returns sane values for {@link #getReturnedClass()} and
+ * {@link #getAnnotationsMethod()}.
+ *
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class ParameterizedParameterType implements DynamicParameterizedType.ParameterType {
+
+    private final Class<?> clasz;
+
+    public ParameterizedParameterType(Class<?> clasz) {
+        this.clasz = clasz;
+    }
+
+    @Override
+    public Class getReturnedClass() {
+        return clasz;
+    }
+
+    @Override
+    public Annotation[] getAnnotationsMethod() {
+        return new Annotation[0];
+    }
+
+    @Override
+    public String getCatalog() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSchema() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPrimaryKey() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getColumns() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/EnumArrayType.java
@@ -4,6 +4,7 @@ import com.vladmihalcea.hibernate.type.AbstractHibernateType;
 import com.vladmihalcea.hibernate.type.array.internal.ArraySqlTypeDescriptor;
 import com.vladmihalcea.hibernate.type.array.internal.EnumArrayTypeDescriptor;
 import com.vladmihalcea.hibernate.type.util.Configuration;
+import com.vladmihalcea.hibernate.type.util.ParameterizedParameterType;
 import org.hibernate.annotations.Type;
 import org.hibernate.usertype.DynamicParameterizedType;
 
@@ -43,6 +44,14 @@ public class EnumArrayType
         );
     }
 
+    public EnumArrayType(Class<? extends Enum> enumClass, String sqlArrayType) {
+        this();
+        Properties parameters = new Properties();
+        parameters.setProperty(SQL_ARRAY_TYPE, sqlArrayType);
+        parameters.put(DynamicParameterizedType.PARAMETER_TYPE, new ParameterizedParameterType(enumClass));
+        setParameterValues(parameters);
+    }
+
     public String getName() {
         return name;
     }
@@ -55,7 +64,6 @@ public class EnumArrayType
     @Override
     public void setParameterValues(Properties parameters) {
         DynamicParameterizedType.ParameterType parameterType = (ParameterType) parameters.get(DynamicParameterizedType.PARAMETER_TYPE);
-
         Annotation[] annotations = parameterType.getAnnotationsMethod();
         if (annotations != null) {
             for (int i = 0; i < annotations.length; i++) {
@@ -72,4 +80,5 @@ public class EnumArrayType
         }
         ((EnumArrayTypeDescriptor) getJavaTypeDescriptor()).setParameterValues(parameters);
     }
+
 }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLEnumType.java
@@ -3,10 +3,14 @@ package com.vladmihalcea.hibernate.type.basic;
 import com.vladmihalcea.hibernate.type.util.Configuration;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.descriptor.java.EnumJavaTypeDescriptor;
+import org.hibernate.type.descriptor.java.spi.JavaTypeDescriptorRegistry;
+import org.hibernate.type.spi.TypeConfiguration;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Properties;
 
 /**
  * Maps an {@link Enum} to a PostgreSQL ENUM column type.
@@ -25,16 +29,42 @@ public class PostgreSQLEnumType extends org.hibernate.type.EnumType {
      * Initialization constructor taking the default {@link Configuration} object.
      */
     public PostgreSQLEnumType() {
-        this.configuration = Configuration.INSTANCE;
+        this(Configuration.INSTANCE);
     }
 
     /**
-     * Initialization constructor taking the {@link Class} and {@link Configuration} objects.
+     * Initialization constructor taking a custom {@link Configuration} object.
      *
      * @param configuration custom {@link Configuration} object.
      */
     public PostgreSQLEnumType(Configuration configuration) {
         this.configuration = configuration;
+    }
+
+    /**
+     * Initialization constructor taking the {@link Class}.
+     *
+     * @param enumClass The enum type
+     */
+    public PostgreSQLEnumType(Class<? extends Enum> enumClass) {
+        this();
+
+        setTypeConfiguration(new TypeConfiguration() {
+            @Override
+            public JavaTypeDescriptorRegistry getJavaTypeDescriptorRegistry() {
+                return new JavaTypeDescriptorRegistry(this) {
+                    @Override
+                    public EnumJavaTypeDescriptor getDescriptor(Class javaType) {
+                        return new EnumJavaTypeDescriptor(enumClass);
+                    }
+                };
+            }
+        });
+
+        Properties properties = new Properties();
+        properties.setProperty("enumClass", enumClass.getName());
+        properties.setProperty("useNamed", Boolean.TRUE.toString());
+        setParameterValues(properties);
     }
 
     public void nullSafeSet(

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ParameterizedParameterType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ParameterizedParameterType.java
@@ -1,0 +1,55 @@
+package com.vladmihalcea.hibernate.type.util;
+
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A stub {@code ParameterType} that returns sane values for {@link #getReturnedClass()} and
+ * {@link #getAnnotationsMethod()}.
+ *
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class ParameterizedParameterType implements DynamicParameterizedType.ParameterType {
+
+    private final Class<?> clasz;
+
+    public ParameterizedParameterType(Class<?> clasz) {
+        this.clasz = clasz;
+    }
+
+    @Override
+    public Class getReturnedClass() {
+        return clasz;
+    }
+
+    @Override
+    public Annotation[] getAnnotationsMethod() {
+        return new Annotation[0];
+    }
+
+    @Override
+    public String getCatalog() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getSchema() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPrimaryKey() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String[] getColumns() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
This allows the instantation of `PostgreSQLEnumType`  and `EnumArrayType` with the parameters normally set through `DynamicParameterizedType` set through the constructor. This allows for the `PostgreSQLEnumType`  and `EnumArrayType` to be used with [`org.hibernate.Query#setParameter(int position, Object val, Type type)`](https://docs.jboss.org/hibernate/orm/5.4/javadocs/org/hibernate/Query.html#setParameter-int-java.lang.Object-org.hibernate.type.Type-) or as [`TypedParameterValue`](https://docs.jboss.org/hibernate/orm/5.4/javadocs/org/hibernate/jpa/TypedParameterValue.html). As both methods are introduced in Hibernate 5.x, the changes are only ported to the modules targeting Hibernate 5.x. This applies both my fix and the suggestion to stub the `TypeConfiguration`, as both are required to make the test work. I also had to stub `DynamicParameterizedType.ParameterType` for the `EnumArrayType` - this could also be done differently, but this requires minimal changes to the types themselves.

Fixes #124