### PR TITLE
Add support for mapping a Guava Range object to a PostgreSQL range type

### DIFF
--- a/hibernate-types-4/pom.xml
+++ b/hibernate-types-4/pom.xml
@@ -40,6 +40,14 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-ehcache</artifactId>
             <version>${hibernate.version}</version>
@@ -66,6 +74,7 @@
         <hibernate.version>4.2.21.Final</hibernate.version>
         <postgresql.version>9.4-1202-jdbc4</postgresql.version>
         <jackson.version>2.7.9.6</jackson.version>
+        <guava.version>27.1-jre</guava.version>
     </properties>
 
     <build>

--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
@@ -1,0 +1,229 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.postgresql.util.PGobject;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link Range} object type to a PostgreSQL <a href="https://www.postgresql.org/docs/current/rangetypes.html">range</a>
+ * column type.
+ * <p>
+ * Supported range types:
+ * <ul>
+ * <li>int4range</li>
+ * <li>int8range</li>
+ * <li>numrange</li>
+ * <li>tsrange</li>
+ * <li>tstzrange</li>
+ * <li>daterange</li>
+ * </ul>
+ *
+ * @author Edgar Asatryan
+ * @author Vlad Mihalcea
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeType extends ImmutableType<Range> {
+
+    public static final PostgreSQLGuavaRangeType INSTANCE = new PostgreSQLGuavaRangeType();
+
+    public PostgreSQLGuavaRangeType() {
+        super(Range.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected Range get(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws SQLException {
+        PGobject pgObject = (PGobject) rs.getObject(names[0]);
+
+        if (pgObject == null) {
+            return null;
+        }
+
+        String type = pgObject.getType();
+        String value = pgObject.getValue();
+
+        if("int4range".equals(type)) {
+            return integerRange(value);
+        } else if("int8range".equals(type)) {
+            return longRange(value);
+        } else if("numrange".equals(type)) {
+            return bigDecimalRange(value);
+        } else {
+            throw new IllegalStateException("The range type [" + type + "] is not supported!");
+        }
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Range range, int index, SessionImplementor session) throws SQLException {
+
+        if (range == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            PGobject object = new PGobject();
+            object.setType(determineRangeType(range));
+            object.setValue(asString(range));
+
+            st.setObject(index, object);
+        }
+    }
+
+    private static String determineRangeType(Range<?> range) {
+        Object anyEndpoint = range.hasLowerBound() ? range.lowerEndpoint() : range.upperEndpoint();
+        Class<?> clazz = anyEndpoint.getClass();
+
+        if (clazz.equals(Integer.class)) {
+            return "int4range";
+        } else if (clazz.equals(Long.class)) {
+            return "int8range";
+        } else if (clazz.equals(BigDecimal.class)) {
+            return "numrange";
+        }
+
+        throw new IllegalStateException("The class [" + clazz.getName() + "] is not supported!");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Comparable> Range<T> ofString(String str, Function<String, T> converter, Class<T> cls) {
+        BoundType lowerBound = str.charAt(0) == '[' ? BoundType.CLOSED : BoundType.OPEN;
+        BoundType upperBound = str.charAt(str.length() - 1) == ']' ? BoundType.CLOSED : BoundType.OPEN;
+
+        int delim = str.indexOf(',');
+
+        if (delim == -1) {
+            throw new IllegalArgumentException("Cannot find comma character");
+        }
+
+        String lowerStr = str.substring(1, delim);
+        String upperStr = str.substring(delim + 1, str.length() - 1);
+
+        T lower = null;
+        T upper = null;
+
+        if (lowerStr.length() > 0) {
+            lower = converter.apply(lowerStr);
+        }
+
+        if (upperStr.length() > 0) {
+            upper = converter.apply(upperStr);
+        }
+
+        if (lowerStr.length() == 0) {
+            return upperBound == BoundType.CLOSED ?
+                    Range.atMost(upper) :
+                    Range.lessThan(upper);
+        } else if (upperStr.length() == 0) {
+            return lowerBound == BoundType.CLOSED ?
+                    Range.atLeast(upper) :
+                    Range.greaterThan(upper);
+        } else {
+            return Range.range(lower, lowerBound, upper, upperBound);
+        }
+    }
+
+    /**
+     * Creates the {@code BigDecimal} range from provided string:
+     * <pre>{@code
+     *     Range<BigDecimal> closed = Range.bigDecimalRange("[0.1,1.1]");
+     *     Range<BigDecimal> halfOpen = Range.bigDecimalRange("(0.1,1.1]");
+     *     Range<BigDecimal> open = Range.bigDecimalRange("(0.1,1.1)");
+     *     Range<BigDecimal> leftUnbounded = Range.bigDecimalRange("(,1.1)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5.5,7.8]"}.
+     *
+     * @return The range of {@code BigDecimal}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<BigDecimal> bigDecimalRange(String range) {
+        return ofString(range, new Function<String, BigDecimal>() {
+            @Override
+            public BigDecimal apply(String s) {
+                return new BigDecimal(s);
+            }
+        }, BigDecimal.class);
+    }
+
+    /**
+     * Creates the {@code Integer} range from provided string:
+     * <pre>{@code
+     *     Range<Integer> closed = Range.integerRange("[1,5]");
+     *     Range<Integer> halfOpen = Range.integerRange("(-1,1]");
+     *     Range<Integer> open = Range.integerRange("(1,2)");
+     *     Range<Integer> leftUnbounded = Range.integerRange("(,10)");
+     *     Range<Integer> unbounded = Range.integerRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Integer}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Integer> integerRange(String range) {
+        return ofString(range, new Function<String, Integer>() {
+            @Override
+            public Integer apply(String s) {
+                return Integer.parseInt(s);
+            }
+        }, Integer.class);
+    }
+
+    /**
+     * Creates the {@code Long} range from provided string:
+     * <pre>{@code
+     *     Range<Long> closed = Range.longRange("[1,5]");
+     *     Range<Long> halfOpen = Range.longRange("(-1,1]");
+     *     Range<Long> open = Range.longRange("(1,2)");
+     *     Range<Long> leftUnbounded = Range.longRange("(,10)");
+     *     Range<Long> unbounded = Range.longRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Long}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Long> longRange(String range) {
+        return ofString(range, new Function<String, Long>() {
+            @Override
+            public Long apply(String s) {
+                return Long.parseLong(s);
+            }
+        }, Long.class);
+    }
+
+    public String asString(Range range) {
+        StringBuilder sb = new StringBuilder();
+
+
+        sb.append(range.lowerBoundType() == BoundType.CLOSED ? '[' : '(')
+                .append(range.hasLowerBound() ? range.lowerEndpoint().toString() : "")
+                .append(",")
+                .append(range.hasUpperBound() ? range.upperEndpoint().toString() : "")
+                .append(range.upperBoundType() == BoundType.CLOSED ? ']' : ')');
+
+        return sb.toString();
+    }
+
+    public interface Function<T, R> {
+
+        R apply(T t);
+    }
+
+
+}

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
@@ -1,0 +1,144 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionVoidFunction;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Edgar Asatryan
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    private final Range<BigDecimal> numeric = Range.closedOpen(new BigDecimal("0.5"), new BigDecimal("0.89"));
+
+    private final Range<Long> int8Range = Range.closedOpen(0L, 18L);
+
+    private final Range<Integer> int4Range = Range.closedOpen(0, 18);
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[]{
+                Restriction.class
+        };
+    }
+
+    @Test
+    public void test() {
+
+        final Restriction ageRestrictionInt = doInJPA(new JPATransactionFunction<Restriction>() {
+
+            @Override
+            public Restriction apply(EntityManager entityManager) {
+                entityManager.persist(new Restriction());
+
+                Restriction restriction = new Restriction();
+                restriction.setRangeInt(int4Range);
+                restriction.setRangeLong(int8Range);
+                restriction.setRangeBigDecimal(numeric);
+                entityManager.persist(restriction);
+
+                return restriction;
+            }
+        });
+
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+                assertEquals(int4Range, ar.getRangeInt());
+                assertEquals(int8Range, ar.getRangeLong());
+                assertEquals(numeric, ar.getRangeBigDecimal());
+
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testNullRange() {
+        final Restriction ageRestrictionInt = doInJPA(new JPATransactionFunction<Restriction>() {
+            @Override
+            public Restriction apply(EntityManager entityManager) {
+                Restriction restriction = new Restriction();
+                entityManager.persist(restriction);
+
+                return restriction;
+            }
+        });
+
+        doInJPA(new JPATransactionVoidFunction() {
+            @Override
+            public void accept(EntityManager entityManager) {
+                Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+                assertNull(ar.getRangeInt());
+                assertNull(ar.getRangeLong());
+                assertNull(ar.getRangeBigDecimal());
+            }
+        });
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    @TypeDef(name = "range", typeClass = PostgreSQLGuavaRangeType.class, defaultForType = Range.class)
+    public static class Restriction {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Column(name = "r_int", columnDefinition = "int4Range")
+        private Range<Integer> rangeInt;
+
+        @Column(name = "r_long", columnDefinition = "int8range")
+        private Range<Long> rangeLong;
+
+        @Column(name = "r_numeric", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimal;
+
+        public Long getId() {
+            return id;
+        }
+
+        public Range<Long> getRangeLong() {
+            return rangeLong;
+        }
+
+        public void setRangeLong(Range<Long> rangeLong) {
+            this.rangeLong = rangeLong;
+        }
+
+        public Range<Integer> getRangeInt() {
+            return rangeInt;
+        }
+
+        public void setRangeInt(Range<Integer> rangeInt) {
+            this.rangeInt = rangeInt;
+        }
+
+        public Range<BigDecimal> getRangeBigDecimal() {
+            return rangeBigDecimal;
+        }
+
+        public void setRangeBigDecimal(Range<BigDecimal> rangeBigDecimal) {
+            this.rangeBigDecimal = rangeBigDecimal;
+        }
+    }
+}

--- a/hibernate-types-43/pom.xml
+++ b/hibernate-types-43/pom.xml
@@ -40,6 +40,14 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-ehcache</artifactId>
             <version>${hibernate.version}</version>
@@ -66,6 +74,7 @@
         <hibernate.version>4.3.11.Final</hibernate.version>
         <postgresql.version>9.4-1202-jdbc4</postgresql.version>
         <jackson.version>2.7.9.6</jackson.version>
+        <guava.version>27.1-jre</guava.version>
     </properties>
 
     <build>

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
@@ -1,0 +1,229 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.postgresql.util.PGobject;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link Range} object type to a PostgreSQL <a href="https://www.postgresql.org/docs/current/rangetypes.html">range</a>
+ * column type.
+ * <p>
+ * Supported range types:
+ * <ul>
+ * <li>int4range</li>
+ * <li>int8range</li>
+ * <li>numrange</li>
+ * <li>tsrange</li>
+ * <li>tstzrange</li>
+ * <li>daterange</li>
+ * </ul>
+ *
+ * @author Edgar Asatryan
+ * @author Vlad Mihalcea
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeType extends ImmutableType<Range> {
+
+    public static final PostgreSQLGuavaRangeType INSTANCE = new PostgreSQLGuavaRangeType();
+
+    public PostgreSQLGuavaRangeType() {
+        super(Range.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected Range get(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws SQLException {
+        PGobject pgObject = (PGobject) rs.getObject(names[0]);
+
+        if (pgObject == null) {
+            return null;
+        }
+
+        String type = pgObject.getType();
+        String value = pgObject.getValue();
+
+        if("int4range".equals(type)) {
+            return integerRange(value);
+        } else if("int8range".equals(type)) {
+            return longRange(value);
+        } else if("numrange".equals(type)) {
+            return bigDecimalRange(value);
+        } else {
+            throw new IllegalStateException("The range type [" + type + "] is not supported!");
+        }
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Range range, int index, SessionImplementor session) throws SQLException {
+
+        if (range == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            PGobject object = new PGobject();
+            object.setType(determineRangeType(range));
+            object.setValue(asString(range));
+
+            st.setObject(index, object);
+        }
+    }
+
+    private static String determineRangeType(Range<?> range) {
+        Object anyEndpoint = range.hasLowerBound() ? range.lowerEndpoint() : range.upperEndpoint();
+        Class<?> clazz = anyEndpoint.getClass();
+
+        if (clazz.equals(Integer.class)) {
+            return "int4range";
+        } else if (clazz.equals(Long.class)) {
+            return "int8range";
+        } else if (clazz.equals(BigDecimal.class)) {
+            return "numrange";
+        }
+
+        throw new IllegalStateException("The class [" + clazz.getName() + "] is not supported!");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Comparable> Range<T> ofString(String str, Function<String, T> converter, Class<T> cls) {
+        BoundType lowerBound = str.charAt(0) == '[' ? BoundType.CLOSED : BoundType.OPEN;
+        BoundType upperBound = str.charAt(str.length() - 1) == ']' ? BoundType.CLOSED : BoundType.OPEN;
+
+        int delim = str.indexOf(',');
+
+        if (delim == -1) {
+            throw new IllegalArgumentException("Cannot find comma character");
+        }
+
+        String lowerStr = str.substring(1, delim);
+        String upperStr = str.substring(delim + 1, str.length() - 1);
+
+        T lower = null;
+        T upper = null;
+
+        if (lowerStr.length() > 0) {
+            lower = converter.apply(lowerStr);
+        }
+
+        if (upperStr.length() > 0) {
+            upper = converter.apply(upperStr);
+        }
+
+        if (lowerStr.length() == 0) {
+            return upperBound == BoundType.CLOSED ?
+                    Range.atMost(upper) :
+                    Range.lessThan(upper);
+        } else if (upperStr.length() == 0) {
+            return lowerBound == BoundType.CLOSED ?
+                    Range.atLeast(upper) :
+                    Range.greaterThan(upper);
+        } else {
+            return Range.range(lower, lowerBound, upper, upperBound);
+        }
+    }
+
+    /**
+     * Creates the {@code BigDecimal} range from provided string:
+     * <pre>{@code
+     *     Range<BigDecimal> closed = Range.bigDecimalRange("[0.1,1.1]");
+     *     Range<BigDecimal> halfOpen = Range.bigDecimalRange("(0.1,1.1]");
+     *     Range<BigDecimal> open = Range.bigDecimalRange("(0.1,1.1)");
+     *     Range<BigDecimal> leftUnbounded = Range.bigDecimalRange("(,1.1)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5.5,7.8]"}.
+     *
+     * @return The range of {@code BigDecimal}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<BigDecimal> bigDecimalRange(String range) {
+        return ofString(range, new Function<String, BigDecimal>() {
+            @Override
+            public BigDecimal apply(String s) {
+                return new BigDecimal(s);
+            }
+        }, BigDecimal.class);
+    }
+
+    /**
+     * Creates the {@code Integer} range from provided string:
+     * <pre>{@code
+     *     Range<Integer> closed = Range.integerRange("[1,5]");
+     *     Range<Integer> halfOpen = Range.integerRange("(-1,1]");
+     *     Range<Integer> open = Range.integerRange("(1,2)");
+     *     Range<Integer> leftUnbounded = Range.integerRange("(,10)");
+     *     Range<Integer> unbounded = Range.integerRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Integer}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Integer> integerRange(String range) {
+        return ofString(range, new Function<String, Integer>() {
+            @Override
+            public Integer apply(String s) {
+                return Integer.parseInt(s);
+            }
+        }, Integer.class);
+    }
+
+    /**
+     * Creates the {@code Long} range from provided string:
+     * <pre>{@code
+     *     Range<Long> closed = Range.longRange("[1,5]");
+     *     Range<Long> halfOpen = Range.longRange("(-1,1]");
+     *     Range<Long> open = Range.longRange("(1,2)");
+     *     Range<Long> leftUnbounded = Range.longRange("(,10)");
+     *     Range<Long> unbounded = Range.longRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Long}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Long> longRange(String range) {
+        return ofString(range, new Function<String, Long>() {
+            @Override
+            public Long apply(String s) {
+                return Long.parseLong(s);
+            }
+        }, Long.class);
+    }
+
+    public String asString(Range range) {
+        StringBuilder sb = new StringBuilder();
+
+
+        sb.append(range.lowerBoundType() == BoundType.CLOSED ? '[' : '(')
+                .append(range.hasLowerBound() ? range.lowerEndpoint().toString() : "")
+                .append(",")
+                .append(range.hasUpperBound() ? range.upperEndpoint().toString() : "")
+                .append(range.upperBoundType() == BoundType.CLOSED ? ']' : ')');
+
+        return sb.toString();
+    }
+
+    public interface Function<T, R> {
+
+        R apply(T t);
+    }
+
+
+}

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
@@ -1,0 +1,144 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionVoidFunction;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Edgar Asatryan
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    private final Range<BigDecimal> numeric = Range.closedOpen(new BigDecimal("0.5"), new BigDecimal("0.89"));
+
+    private final Range<Long> int8Range = Range.closedOpen(0L, 18L);
+
+    private final Range<Integer> int4Range = Range.closedOpen(0, 18);
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[]{
+                Restriction.class
+        };
+    }
+
+    @Test
+    public void test() {
+
+        final Restriction ageRestrictionInt = doInJPA(new JPATransactionFunction<Restriction>() {
+
+            @Override
+            public Restriction apply(EntityManager entityManager) {
+                entityManager.persist(new Restriction());
+
+                Restriction restriction = new Restriction();
+                restriction.setRangeInt(int4Range);
+                restriction.setRangeLong(int8Range);
+                restriction.setRangeBigDecimal(numeric);
+                entityManager.persist(restriction);
+
+                return restriction;
+            }
+        });
+
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+                assertEquals(int4Range, ar.getRangeInt());
+                assertEquals(int8Range, ar.getRangeLong());
+                assertEquals(numeric, ar.getRangeBigDecimal());
+
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testNullRange() {
+        final Restriction ageRestrictionInt = doInJPA(new JPATransactionFunction<Restriction>() {
+            @Override
+            public Restriction apply(EntityManager entityManager) {
+                Restriction restriction = new Restriction();
+                entityManager.persist(restriction);
+
+                return restriction;
+            }
+        });
+
+        doInJPA(new JPATransactionVoidFunction() {
+            @Override
+            public void accept(EntityManager entityManager) {
+                Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+                assertNull(ar.getRangeInt());
+                assertNull(ar.getRangeLong());
+                assertNull(ar.getRangeBigDecimal());
+            }
+        });
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    @TypeDef(name = "range", typeClass = PostgreSQLGuavaRangeType.class, defaultForType = Range.class)
+    public static class Restriction {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Column(name = "r_int", columnDefinition = "int4Range")
+        private Range<Integer> rangeInt;
+
+        @Column(name = "r_long", columnDefinition = "int8range")
+        private Range<Long> rangeLong;
+
+        @Column(name = "r_numeric", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimal;
+
+        public Long getId() {
+            return id;
+        }
+
+        public Range<Long> getRangeLong() {
+            return rangeLong;
+        }
+
+        public void setRangeLong(Range<Long> rangeLong) {
+            this.rangeLong = rangeLong;
+        }
+
+        public Range<Integer> getRangeInt() {
+            return rangeInt;
+        }
+
+        public void setRangeInt(Range<Integer> rangeInt) {
+            this.rangeInt = rangeInt;
+        }
+
+        public Range<BigDecimal> getRangeBigDecimal() {
+            return rangeBigDecimal;
+        }
+
+        public void setRangeBigDecimal(Range<BigDecimal> rangeBigDecimal) {
+            this.rangeBigDecimal = rangeBigDecimal;
+        }
+    }
+}

--- a/hibernate-types-5/pom.xml
+++ b/hibernate-types-5/pom.xml
@@ -40,6 +40,14 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-ehcache</artifactId>
             <version>${hibernate.version}</version>
@@ -66,6 +74,7 @@
         <hibernate.version>5.1.10.Final</hibernate.version>
         <postgresql.version>9.4-1202-jdbc4</postgresql.version>
         <jackson.version>2.7.9.6</jackson.version>
+        <guava.version>27.1-jre</guava.version>
     </properties>
 
     <build>

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
@@ -1,0 +1,229 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.postgresql.util.PGobject;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link Range} object type to a PostgreSQL <a href="https://www.postgresql.org/docs/current/rangetypes.html">range</a>
+ * column type.
+ * <p>
+ * Supported range types:
+ * <ul>
+ * <li>int4range</li>
+ * <li>int8range</li>
+ * <li>numrange</li>
+ * <li>tsrange</li>
+ * <li>tstzrange</li>
+ * <li>daterange</li>
+ * </ul>
+ *
+ * @author Edgar Asatryan
+ * @author Vlad Mihalcea
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeType extends ImmutableType<Range> {
+
+    public static final PostgreSQLGuavaRangeType INSTANCE = new PostgreSQLGuavaRangeType();
+
+    public PostgreSQLGuavaRangeType() {
+        super(Range.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected Range get(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws SQLException {
+        PGobject pgObject = (PGobject) rs.getObject(names[0]);
+
+        if (pgObject == null) {
+            return null;
+        }
+
+        String type = pgObject.getType();
+        String value = pgObject.getValue();
+
+        if("int4range".equals(type)) {
+            return integerRange(value);
+        } else if("int8range".equals(type)) {
+            return longRange(value);
+        } else if("numrange".equals(type)) {
+            return bigDecimalRange(value);
+        } else {
+            throw new IllegalStateException("The range type [" + type + "] is not supported!");
+        }
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Range range, int index, SessionImplementor session) throws SQLException {
+
+        if (range == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            PGobject object = new PGobject();
+            object.setType(determineRangeType(range));
+            object.setValue(asString(range));
+
+            st.setObject(index, object);
+        }
+    }
+
+    private static String determineRangeType(Range<?> range) {
+        Object anyEndpoint = range.hasLowerBound() ? range.lowerEndpoint() : range.upperEndpoint();
+        Class<?> clazz = anyEndpoint.getClass();
+
+        if (clazz.equals(Integer.class)) {
+            return "int4range";
+        } else if (clazz.equals(Long.class)) {
+            return "int8range";
+        } else if (clazz.equals(BigDecimal.class)) {
+            return "numrange";
+        }
+
+        throw new IllegalStateException("The class [" + clazz.getName() + "] is not supported!");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Comparable> Range<T> ofString(String str, Function<String, T> converter, Class<T> cls) {
+        BoundType lowerBound = str.charAt(0) == '[' ? BoundType.CLOSED : BoundType.OPEN;
+        BoundType upperBound = str.charAt(str.length() - 1) == ']' ? BoundType.CLOSED : BoundType.OPEN;
+
+        int delim = str.indexOf(',');
+
+        if (delim == -1) {
+            throw new IllegalArgumentException("Cannot find comma character");
+        }
+
+        String lowerStr = str.substring(1, delim);
+        String upperStr = str.substring(delim + 1, str.length() - 1);
+
+        T lower = null;
+        T upper = null;
+
+        if (lowerStr.length() > 0) {
+            lower = converter.apply(lowerStr);
+        }
+
+        if (upperStr.length() > 0) {
+            upper = converter.apply(upperStr);
+        }
+
+        if (lowerStr.length() == 0) {
+            return upperBound == BoundType.CLOSED ?
+                    Range.atMost(upper) :
+                    Range.lessThan(upper);
+        } else if (upperStr.length() == 0) {
+            return lowerBound == BoundType.CLOSED ?
+                    Range.atLeast(upper) :
+                    Range.greaterThan(upper);
+        } else {
+            return Range.range(lower, lowerBound, upper, upperBound);
+        }
+    }
+
+    /**
+     * Creates the {@code BigDecimal} range from provided string:
+     * <pre>{@code
+     *     Range<BigDecimal> closed = Range.bigDecimalRange("[0.1,1.1]");
+     *     Range<BigDecimal> halfOpen = Range.bigDecimalRange("(0.1,1.1]");
+     *     Range<BigDecimal> open = Range.bigDecimalRange("(0.1,1.1)");
+     *     Range<BigDecimal> leftUnbounded = Range.bigDecimalRange("(,1.1)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5.5,7.8]"}.
+     *
+     * @return The range of {@code BigDecimal}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<BigDecimal> bigDecimalRange(String range) {
+        return ofString(range, new Function<String, BigDecimal>() {
+            @Override
+            public BigDecimal apply(String s) {
+                return new BigDecimal(s);
+            }
+        }, BigDecimal.class);
+    }
+
+    /**
+     * Creates the {@code Integer} range from provided string:
+     * <pre>{@code
+     *     Range<Integer> closed = Range.integerRange("[1,5]");
+     *     Range<Integer> halfOpen = Range.integerRange("(-1,1]");
+     *     Range<Integer> open = Range.integerRange("(1,2)");
+     *     Range<Integer> leftUnbounded = Range.integerRange("(,10)");
+     *     Range<Integer> unbounded = Range.integerRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Integer}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Integer> integerRange(String range) {
+        return ofString(range, new Function<String, Integer>() {
+            @Override
+            public Integer apply(String s) {
+                return Integer.parseInt(s);
+            }
+        }, Integer.class);
+    }
+
+    /**
+     * Creates the {@code Long} range from provided string:
+     * <pre>{@code
+     *     Range<Long> closed = Range.longRange("[1,5]");
+     *     Range<Long> halfOpen = Range.longRange("(-1,1]");
+     *     Range<Long> open = Range.longRange("(1,2)");
+     *     Range<Long> leftUnbounded = Range.longRange("(,10)");
+     *     Range<Long> unbounded = Range.longRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Long}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Long> longRange(String range) {
+        return ofString(range, new Function<String, Long>() {
+            @Override
+            public Long apply(String s) {
+                return Long.parseLong(s);
+            }
+        }, Long.class);
+    }
+
+    public String asString(Range range) {
+        StringBuilder sb = new StringBuilder();
+
+
+        sb.append(range.lowerBoundType() == BoundType.CLOSED ? '[' : '(')
+                .append(range.hasLowerBound() ? range.lowerEndpoint().toString() : "")
+                .append(",")
+                .append(range.hasUpperBound() ? range.upperEndpoint().toString() : "")
+                .append(range.upperBoundType() == BoundType.CLOSED ? ']' : ')');
+
+        return sb.toString();
+    }
+
+    public interface Function<T, R> {
+
+        R apply(T t);
+    }
+
+
+}

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
@@ -1,0 +1,144 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionFunction;
+import com.vladmihalcea.hibernate.type.util.transaction.JPATransactionVoidFunction;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Edgar Asatryan
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    private final Range<BigDecimal> numeric = Range.closedOpen(new BigDecimal("0.5"), new BigDecimal("0.89"));
+
+    private final Range<Long> int8Range = Range.closedOpen(0L, 18L);
+
+    private final Range<Integer> int4Range = Range.closedOpen(0, 18);
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[]{
+                Restriction.class
+        };
+    }
+
+    @Test
+    public void test() {
+
+        final Restriction ageRestrictionInt = doInJPA(new JPATransactionFunction<Restriction>() {
+
+            @Override
+            public Restriction apply(EntityManager entityManager) {
+                entityManager.persist(new Restriction());
+
+                Restriction restriction = new Restriction();
+                restriction.setRangeInt(int4Range);
+                restriction.setRangeLong(int8Range);
+                restriction.setRangeBigDecimal(numeric);
+                entityManager.persist(restriction);
+
+                return restriction;
+            }
+        });
+
+        doInJPA(new JPATransactionFunction<Void>() {
+
+            @Override
+            public Void apply(EntityManager entityManager) {
+                Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+                assertEquals(int4Range, ar.getRangeInt());
+                assertEquals(int8Range, ar.getRangeLong());
+                assertEquals(numeric, ar.getRangeBigDecimal());
+
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testNullRange() {
+        final Restriction ageRestrictionInt = doInJPA(new JPATransactionFunction<Restriction>() {
+            @Override
+            public Restriction apply(EntityManager entityManager) {
+                Restriction restriction = new Restriction();
+                entityManager.persist(restriction);
+
+                return restriction;
+            }
+        });
+
+        doInJPA(new JPATransactionVoidFunction() {
+            @Override
+            public void accept(EntityManager entityManager) {
+                Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+                assertNull(ar.getRangeInt());
+                assertNull(ar.getRangeLong());
+                assertNull(ar.getRangeBigDecimal());
+            }
+        });
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    @TypeDef(name = "range", typeClass = PostgreSQLGuavaRangeType.class, defaultForType = Range.class)
+    public static class Restriction {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Column(name = "r_int", columnDefinition = "int4Range")
+        private Range<Integer> rangeInt;
+
+        @Column(name = "r_long", columnDefinition = "int8range")
+        private Range<Long> rangeLong;
+
+        @Column(name = "r_numeric", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimal;
+
+        public Long getId() {
+            return id;
+        }
+
+        public Range<Long> getRangeLong() {
+            return rangeLong;
+        }
+
+        public void setRangeLong(Range<Long> rangeLong) {
+            this.rangeLong = rangeLong;
+        }
+
+        public Range<Integer> getRangeInt() {
+            return rangeInt;
+        }
+
+        public void setRangeInt(Range<Integer> rangeInt) {
+            this.rangeInt = rangeInt;
+        }
+
+        public Range<BigDecimal> getRangeBigDecimal() {
+            return rangeBigDecimal;
+        }
+
+        public void setRangeBigDecimal(Range<BigDecimal> rangeBigDecimal) {
+            this.rangeBigDecimal = rangeBigDecimal;
+        }
+    }
+}

--- a/hibernate-types-52/pom.xml
+++ b/hibernate-types-52/pom.xml
@@ -41,6 +41,14 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-ehcache</artifactId>
             <version>${hibernate.version}</version>
@@ -69,6 +77,7 @@
 
         <mysql.version>8.0.13</mysql.version>
         <jackson.version>2.9.9.2</jackson.version>
+        <guava.version>27.1-jre</guava.version>
 
         <jdk.version>8</jdk.version>
         <jdk>${env.JAVA_HOME_8}</jdk>

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
@@ -1,0 +1,376 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.BoundType;
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.ImmutableType;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.postgresql.util.PGobject;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.function.Function;
+
+/**
+ * Maps a {@link Range} object type to a PostgreSQL <a href="https://www.postgresql.org/docs/current/rangetypes.html">range</a>
+ * column type.
+ * <p>
+ * Supported range types:
+ * <ul>
+ * <li>int4range</li>
+ * <li>int8range</li>
+ * <li>numrange</li>
+ * <li>tsrange</li>
+ * <li>tstzrange</li>
+ * <li>daterange</li>
+ * </ul>
+ *
+ * @author Edgar Asatryan
+ * @author Vlad Mihalcea
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeType extends ImmutableType<Range> {
+
+    private static final DateTimeFormatter LOCAL_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS]");
+
+    private static final DateTimeFormatter ZONE_DATE_TIME = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendPattern(".")
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
+            .optionalEnd()
+            .appendPattern("X")
+            .toFormatter();
+
+    public static final PostgreSQLGuavaRangeType INSTANCE = new PostgreSQLGuavaRangeType();
+
+    public PostgreSQLGuavaRangeType() {
+        super(Range.class);
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.OTHER};
+    }
+
+    @Override
+    protected Range get(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        PGobject pgObject = (PGobject) rs.getObject(names[0]);
+
+        if (pgObject == null) {
+            return null;
+        }
+
+        String type = pgObject.getType();
+        String value = pgObject.getValue();
+
+        switch (type) {
+            case "int4range":
+                return integerRange(value);
+            case "int8range":
+                return longRange(value);
+            case "numrange":
+                return bigDecimalRange(value);
+            case "tsrange":
+                return localDateTimeRange(value);
+            case "tstzrange":
+                return zonedDateTimeRange(value);
+            case "daterange":
+                return localDateRange(value);
+            default:
+                throw new IllegalStateException("The range type [" + type + "] is not supported!");
+        }
+    }
+
+    @Override
+    protected void set(PreparedStatement st, Range range, int index, SharedSessionContractImplementor session) throws SQLException {
+
+        if (range == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            PGobject object = new PGobject();
+            object.setType(determineRangeType(range));
+            object.setValue(asString(range));
+
+            st.setObject(index, object);
+        }
+    }
+
+    private static String determineRangeType(Range<?> range) {
+        Object anyEndpoint = range.hasLowerBound() ? range.lowerEndpoint() : range.upperEndpoint();
+        Class<?> clazz = anyEndpoint.getClass();
+
+        if (clazz.equals(Integer.class)) {
+            return "int4range";
+        } else if (clazz.equals(Long.class)) {
+            return "int8range";
+        } else if (clazz.equals(BigDecimal.class)) {
+            return "numrange";
+        } else if (clazz.equals(LocalDateTime.class)) {
+            return "tsrange";
+        } else if (clazz.equals(ZonedDateTime.class)) {
+            return "tstzrange";
+        } else if (clazz.equals(LocalDate.class)) {
+            return "daterange";
+        }
+
+        throw new IllegalStateException("The class [" + clazz.getName() + "] is not supported!");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Comparable> Range<T> ofString(String str, Function<String, T> converter, Class<T> cls) {
+        BoundType lowerBound = str.charAt(0) == '[' ? BoundType.CLOSED : BoundType.OPEN;
+        BoundType upperBound = str.charAt(str.length() - 1) == ']' ? BoundType.CLOSED : BoundType.OPEN;
+
+        int delim = str.indexOf(',');
+
+        if (delim == -1) {
+            throw new IllegalArgumentException("Cannot find comma character");
+        }
+
+        String lowerStr = str.substring(1, delim);
+        String upperStr = str.substring(delim + 1, str.length() - 1);
+
+        T lower = null;
+        T upper = null;
+
+        if (lowerStr.length() > 0) {
+            lower = converter.apply(lowerStr);
+        }
+
+        if (upperStr.length() > 0) {
+            upper = converter.apply(upperStr);
+        }
+
+        if (lowerStr.length() == 0) {
+            return upperBound == BoundType.CLOSED ?
+                    Range.atMost(upper) :
+                    Range.lessThan(upper);
+        } else if (upperStr.length() == 0) {
+            return lowerBound == BoundType.CLOSED ?
+                    Range.atLeast(upper) :
+                    Range.greaterThan(upper);
+        } else {
+            return Range.range(lower, lowerBound, upper, upperBound);
+        }
+    }
+
+    /**
+     * Creates the {@code BigDecimal} range from provided string:
+     * <pre>{@code
+     *     Range<BigDecimal> closed = Range.bigDecimalRange("[0.1,1.1]");
+     *     Range<BigDecimal> halfOpen = Range.bigDecimalRange("(0.1,1.1]");
+     *     Range<BigDecimal> open = Range.bigDecimalRange("(0.1,1.1)");
+     *     Range<BigDecimal> leftUnbounded = Range.bigDecimalRange("(,1.1)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5.5,7.8]"}.
+     *
+     * @return The range of {@code BigDecimal}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<BigDecimal> bigDecimalRange(String range) {
+        return ofString(range, BigDecimal::new, BigDecimal.class);
+    }
+
+    /**
+     * Creates the {@code Integer} range from provided string:
+     * <pre>{@code
+     *     Range<Integer> closed = Range.integerRange("[1,5]");
+     *     Range<Integer> halfOpen = Range.integerRange("(-1,1]");
+     *     Range<Integer> open = Range.integerRange("(1,2)");
+     *     Range<Integer> leftUnbounded = Range.integerRange("(,10)");
+     *     Range<Integer> unbounded = Range.integerRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Integer}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Integer> integerRange(String range) {
+        return ofString(range, Integer::parseInt, Integer.class);
+    }
+
+    /**
+     * Creates the {@code Long} range from provided string:
+     * <pre>{@code
+     *     Range<Long> closed = Range.longRange("[1,5]");
+     *     Range<Long> halfOpen = Range.longRange("(-1,1]");
+     *     Range<Long> open = Range.longRange("(1,2)");
+     *     Range<Long> leftUnbounded = Range.longRange("(,10)");
+     *     Range<Long> unbounded = Range.longRange("(,)");
+     * }</pre>
+     *
+     * @param range The range string, for example {@literal "[5,7]"}.
+     *
+     * @return The range of {@code Long}s.
+     *
+     * @throws NumberFormatException when one of the bounds are invalid.
+     */
+    public static Range<Long> longRange(String range) {
+        return ofString(range, Long::parseLong, Long.class);
+    }
+
+    /**
+     * Creates the {@code LocalDateTime} range from provided string:
+     * <pre>{@code
+     *     Range<LocalDateTime> closed = Range.localDateTimeRange("[2014-04-28 16:00:49,2015-04-28 16:00:49]");
+     *     Range<LocalDateTime> quoted = Range.localDateTimeRange("[\"2014-04-28 16:00:49\",\"2015-04-28 16:00:49\"]");
+     *     Range<LocalDateTime> iso = Range.localDateTimeRange("[\"2014-04-28T16:00:49.2358\",\"2015-04-28T16:00:49\"]");
+     * }</pre>
+     * <p>
+     * The valid formats for bounds are:
+     * <ul>
+     * <li>yyyy-MM-dd HH:mm:ss[.SSSSSS]</li>
+     * <li>yyyy-MM-dd'T'HH:mm:ss[.SSSSSS]</li>
+     * </ul>
+     *
+     * @param range The range string, for example {@literal "[2014-04-28 16:00:49,2015-04-28 16:00:49]"}.
+     *
+     * @return The range of {@code LocalDateTime}s.
+     *
+     * @throws DateTimeParseException when one of the bounds are invalid.
+     */
+    public static Range<LocalDateTime> localDateTimeRange(String range) {
+        return ofString(range, parseLocalDateTime().compose(unquote()), LocalDateTime.class);
+    }
+
+    /**
+     * Creates the {@code LocalDate} range from provided string:
+     * <pre>{@code
+     *     Range<LocalDate> closed = Range.localDateRange("[2014-04-28,2015-04-289]");
+     *     Range<LocalDate> quoted = Range.localDateRange("[\"2014-04-28\",\"2015-04-28\"]");
+     *     Range<LocalDate> iso = Range.localDateRange("[\"2014-04-28\",\"2015-04-28\"]");
+     * }</pre>
+     * <p>
+     * The valid formats for bounds are:
+     * <ul>
+     * <li>yyyy-MM-dd</li>
+     * <li>yyyy-MM-dd</li>
+     * </ul>
+     *
+     * @param range The range string, for example {@literal "[2014-04-28,2015-04-28]"}.
+     *
+     * @return The range of {@code LocalDate}s.
+     *
+     * @throws DateTimeParseException when one of the bounds are invalid.
+     */
+    public static Range<LocalDate> localDateRange(String range) {
+        Function<String, LocalDate> parseLocalDate = LocalDate::parse;
+        return ofString(range, parseLocalDate.compose(unquote()), LocalDate.class);
+    }
+
+    /**
+     * Creates the {@code ZonedDateTime} range from provided string:
+     * <pre>{@code
+     *     Range<ZonedDateTime> closed = Range.zonedDateTimeRange("[2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00]");
+     *     Range<ZonedDateTime> quoted = Range.zonedDateTimeRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
+     *     Range<ZonedDateTime> iso = Range.zonedDateTimeRange("[2011-12-03T10:15:30+01:00[Europe/Paris], 2012-12-03T10:15:30+01:00[Europe/Paris]]");
+     * }</pre>
+     * <p>
+     * The valid formats for bounds are:
+     * <ul>
+     * <li>yyyy-MM-dd HH:mm:ss[.SSSSSS]X</li>
+     * <li>yyyy-MM-dd'T'HH:mm:ss[.SSSSSS]X</li>
+     * </ul>
+     *
+     * @param rangeStr The range string, for example {@literal "[2011-12-03T10:15:30+01:00,2012-12-03T10:15:30+01:00]"}.
+     *
+     * @return The range of {@code ZonedDateTime}s.
+     *
+     * @throws DateTimeParseException   when one of the bounds are invalid.
+     * @throws IllegalArgumentException when bounds time zones are different.
+     */
+    public static Range<ZonedDateTime> zonedDateTimeRange(String rangeStr) {
+        Range<ZonedDateTime> range = ofString(rangeStr, parseZonedDateTime().compose(unquote()), ZonedDateTime.class);
+        if (range.hasLowerBound() && range.hasUpperBound()) {
+            ZoneId lowerZone = range.lowerEndpoint().getZone();
+            ZoneId upperZone = range.upperEndpoint().getZone();
+            if (!lowerZone.equals(upperZone)) {
+                Duration lowerDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.lowerEndpoint().toInstant());
+                Duration upperDst = ZoneId.systemDefault().getRules().getDaylightSavings(range.upperEndpoint().toInstant());
+                long dstSeconds = upperDst.minus(lowerDst).getSeconds();
+                if(dstSeconds < 0 ) {
+                    dstSeconds *= -1;
+                }
+                long zoneDriftSeconds = ((ZoneOffset) lowerZone).getTotalSeconds() - ((ZoneOffset) upperZone).getTotalSeconds();
+                if (zoneDriftSeconds < 0) {
+                    zoneDriftSeconds *= -1;
+                }
+
+                if (dstSeconds != zoneDriftSeconds) {
+                    throw new IllegalArgumentException("The upper and lower bounds must be in same time zone!");
+                }
+            }
+        }
+        return range;
+    }
+
+    private static Function<String, LocalDateTime> parseLocalDateTime() {
+        return str -> {
+            try {
+                return LocalDateTime.parse(str, LOCAL_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return LocalDateTime.parse(str);
+            }
+        };
+    }
+
+    private static Function<String, ZonedDateTime> parseZonedDateTime() {
+        return s -> {
+            try {
+                return ZonedDateTime.parse(s, ZONE_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                return ZonedDateTime.parse(s);
+            }
+        };
+    }
+
+    private static Function<String, String> unquote() {
+        return s -> {
+            if (s.charAt(0) == '\"' && s.charAt(s.length() - 1) == '\"') {
+                return s.substring(1, s.length() - 1);
+            }
+
+            return s;
+        };
+    }
+
+    public String asString(Range range) {
+        StringBuilder sb = new StringBuilder();
+
+
+        sb.append(range.lowerBoundType() == BoundType.CLOSED ? '[' : '(')
+                .append(range.hasLowerBound() ? asString(range.lowerEndpoint()) : "")
+                .append(",")
+                .append(range.hasUpperBound() ? asString(range.upperEndpoint()) : "")
+                .append(range.upperBoundType() == BoundType.CLOSED ? ']' : ')');
+
+        return sb.toString();
+    }
+
+    private String asString(Object value) {
+        if (value instanceof ZonedDateTime) {
+            return ZONE_DATE_TIME.format((ZonedDateTime) value);
+        }
+        return value.toString();
+    }
+
+
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeTypeTest.java
@@ -1,0 +1,189 @@
+package com.vladmihalcea.hibernate.type.range.guava;
+
+import com.google.common.collect.Range;
+import com.vladmihalcea.hibernate.type.util.AbstractPostgreSQLIntegrationTest;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Edgar Asatryan
+ * @author Jan-Willem Gmelig Meyling
+ */
+public class PostgreSQLGuavaRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    private final Range<BigDecimal> numeric = Range.closedOpen(new BigDecimal("0.5"), new BigDecimal("0.89"));
+
+    private final Range<Long> int8Range = Range.closedOpen(0L, 18L);
+
+    private final Range<Integer> int4Range = Range.closedOpen(0, 18);
+
+    private final Range<LocalDateTime> localDateTimeRange = Range.closed(
+            LocalDateTime.of(2014, Month.APRIL, 28, 16, 0, 49),
+            LocalDateTime.of(2015, Month.APRIL, 28, 16, 0, 49));
+
+    private final Range<ZonedDateTime> tsTz = Range.closed(
+            OffsetDateTime.of(LocalDateTime.of(2007, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime(),
+            OffsetDateTime.of(LocalDateTime.of(2008, Month.DECEMBER, 3, 10, 15, 30), ZoneOffset.ofHours(1)).toZonedDateTime());
+
+    private final Range<LocalDate> dateRange = Range.closedOpen(LocalDate.of(1992, Month.JANUARY, 13), LocalDate.of(1995, Month.JANUARY, 13));
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class[]{
+                Restriction.class
+        };
+    }
+
+    @Test
+    public void test() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            entityManager.persist(new Restriction());
+
+            Restriction restriction = new Restriction();
+            restriction.setRangeInt(int4Range);
+            restriction.setRangeLong(int8Range);
+            restriction.setRangeBigDecimal(numeric);
+            restriction.setRangeLocalDateTime(localDateTimeRange);
+            restriction.setRangeZonedDateTime(tsTz);
+            restriction.setLocalDateRange(dateRange);
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertEquals(int4Range, ar.getRangeInt());
+            assertEquals(int8Range, ar.getRangeLong());
+            assertEquals(numeric, ar.getRangeBigDecimal());
+            assertEquals(localDateTimeRange, ar.getLocalDateTimeRange());
+            assertEquals(dateRange, ar.getLocalDateRange());
+
+            ZoneId zone = ar.getRangeZonedDateTime().lowerEndpoint().getZone();
+
+            ZonedDateTime lower = tsTz.lowerEndpoint().withZoneSameInstant(zone);
+            ZonedDateTime upper = tsTz.upperEndpoint().withZoneSameInstant(zone);
+
+            assertEquals(ar.getRangeZonedDateTime(), Range.closed(lower, upper));
+        });
+    }
+
+    @Test
+    public void testNullRange() {
+        Restriction ageRestrictionInt = doInJPA(entityManager -> {
+            Restriction restriction = new Restriction();
+            entityManager.persist(restriction);
+
+            return restriction;
+        });
+
+        doInJPA(entityManager -> {
+            Restriction ar = entityManager.find(Restriction.class, ageRestrictionInt.getId());
+
+            assertNull(ar.getRangeInt());
+            assertNull(ar.getRangeLong());
+            assertNull(ar.getRangeBigDecimal());
+            assertNull(ar.getLocalDateTimeRange());
+            assertNull(ar.getLocalDateRange());
+            assertNull(ar.getRangeZonedDateTime());
+        });
+    }
+
+    @Entity(name = "AgeRestriction")
+    @Table(name = "age_restriction")
+    @TypeDef(name = "range", typeClass = PostgreSQLGuavaRangeType.class, defaultForType = Range.class)
+    public static class Restriction {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Column(name = "r_int", columnDefinition = "int4Range")
+        private Range<Integer> rangeInt;
+
+        @Column(name = "r_long", columnDefinition = "int8range")
+        private Range<Long> rangeLong;
+
+        @Column(name = "r_numeric", columnDefinition = "numrange")
+        private Range<BigDecimal> rangeBigDecimal;
+
+        @Column(name = "r_tsrange", columnDefinition = "tsrange")
+        private Range<LocalDateTime> rangeLocalDateTime;
+
+        @Column(name = "r_tstzrange", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> rangeZonedDateTime;
+
+        @Column(name = "r_daterange", columnDefinition = "daterange")
+        private Range<LocalDate> localDateRange;
+
+        public Long getId() {
+            return id;
+        }
+
+        public Range<Long> getRangeLong() {
+            return rangeLong;
+        }
+
+        public void setRangeLong(Range<Long> rangeLong) {
+            this.rangeLong = rangeLong;
+        }
+
+        public Range<Integer> getRangeInt() {
+            return rangeInt;
+        }
+
+        public void setRangeInt(Range<Integer> rangeInt) {
+            this.rangeInt = rangeInt;
+        }
+
+        public Range<BigDecimal> getRangeBigDecimal() {
+            return rangeBigDecimal;
+        }
+
+        public void setRangeBigDecimal(Range<BigDecimal> rangeBigDecimal) {
+            this.rangeBigDecimal = rangeBigDecimal;
+        }
+
+        public Range<LocalDateTime> getLocalDateTimeRange() {
+            return rangeLocalDateTime;
+        }
+
+        public void setRangeLocalDateTime(Range<LocalDateTime> rangeLocalDateTime) {
+            this.rangeLocalDateTime = rangeLocalDateTime;
+        }
+
+        public Range<ZonedDateTime> getRangeZonedDateTime() {
+            return rangeZonedDateTime;
+        }
+
+        public void setRangeZonedDateTime(Range<ZonedDateTime> rangeZonedDateTime) {
+            this.rangeZonedDateTime = rangeZonedDateTime;
+        }
+
+        public Range<LocalDate> getLocalDateRange() {
+            return localDateRange;
+        }
+
+        public void setLocalDateRange(Range<LocalDate> localDateRange) {
+            this.localDateRange = localDateRange;
+        }
+    }
+}


### PR DESCRIPTION
Even before there was the `PostgreSQLRangeType`, I had my own range type based on Guava's `Range` class. Lately, while adding `ZonedDateTime` support, I stumbled upon some issues in my parser, and while looking for new solution I saw the existing solution in this repository. My solution has since converged to the one already in the repository. However, I have not been able to fully transition to the `PostgreSQLRangeType`: with a lot of code already using the `Range` API, it is not trivial for me to change my logic back to use `com.vladmihalcea.hibernate.type.range.Range` instead.

I'd understand if you're not interested in merging this pull request because of the redundant nature. However, considering the fact that I am sitting on these changes and that others might be interested in it as well, I thought that I would at least put it out there.

If you do decide to merge this, please do note that I have put the classes in the `com.vladmihalcea.hibernate.type.range.guava` package. While this makes sense for this contribution, this may open the door to other Guava specific types, in which case it would probably be better to create a new `com.vladmihalcea.hibernate.type.guava` package instead.

Note that the infinite range is not supported for this implementation (we cannot detect range type), neither is the empty range (Guava does not support it).