### PR TITLE
GraalVM / Quarkus native build support - Use Thread.currentThread().getContextClassLoader() when calling Class.forName()

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
@@ -29,12 +29,8 @@ public final class ReflectionUtils {
      * @return new Java {@link Object} of the provided type
      */
     public static <T> T newInstance(String className) {
-        try {
-            Class clazz = Class.forName(className);
-            return newInstance(clazz);
-        } catch (ClassNotFoundException e) {
-            throw handleException(e);
-        }
+        Class clazz = getClass(className);
+        return newInstance(clazz);
     }
 
     /**
@@ -430,7 +426,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClass(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) Class.forName(className, false, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw handleException(e);
         }
@@ -447,7 +443,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClassOrNull(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) getClass(className);
         } catch (Exception e) {
             return null;
         }

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
@@ -31,11 +31,7 @@ public class OracleDataSourceProvider implements DataSourceProvider {
 
     @Override
     public Class<? extends DataSource> dataSourceClassName() {
-        try {
-            return (Class<? extends DataSource>) Class.forName("oracle.jdbc.pool.OracleDataSource");
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(e);
-        }
+        return ReflectionUtils.getClass("oracle.jdbc.pool.OracleDataSource");
     }
 
     @Override

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
@@ -29,12 +29,8 @@ public final class ReflectionUtils {
      * @return new Java {@link Object} of the provided type
      */
     public static <T> T newInstance(String className) {
-        try {
-            Class clazz = Class.forName(className);
-            return newInstance(clazz);
-        } catch (ClassNotFoundException e) {
-            throw handleException(e);
-        }
+        Class clazz = getClass(className);
+        return newInstance(clazz);
     }
 
     /**
@@ -430,7 +426,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClass(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) Class.forName(className, false, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw handleException(e);
         }
@@ -447,7 +443,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClassOrNull(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) getClass(className);
         } catch (Exception e) {
             return null;
         }

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
@@ -31,11 +31,7 @@ public class OracleDataSourceProvider implements DataSourceProvider {
 
     @Override
     public Class<? extends DataSource> dataSourceClassName() {
-        try {
-            return (Class<? extends DataSource>) Class.forName("oracle.jdbc.pool.OracleDataSource");
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(e);
-        }
+        return ReflectionUtils.getClass("oracle.jdbc.pool.OracleDataSource");
     }
 
     @Override

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
@@ -29,12 +29,8 @@ public final class ReflectionUtils {
      * @return new Java {@link Object} of the provided type
      */
     public static <T> T newInstance(String className) {
-        try {
-            Class clazz = Class.forName(className);
-            return newInstance(clazz);
-        } catch (ClassNotFoundException e) {
-            throw handleException(e);
-        }
+        Class clazz = getClass(className);
+        return newInstance(clazz);
     }
 
     /**
@@ -430,7 +426,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClass(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) Class.forName(className, false, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw handleException(e);
         }
@@ -447,7 +443,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClassOrNull(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) getClass(className);
         } catch (Exception e) {
             return null;
         }

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
@@ -35,11 +35,7 @@ public class OracleDataSourceProvider implements DataSourceProvider {
 
     @Override
     public Class<? extends DataSource> dataSourceClassName() {
-        try {
-            return (Class<? extends DataSource>) Class.forName("oracle.jdbc.pool.OracleDataSource");
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(e);
-        }
+        return ReflectionUtils.getClass("oracle.jdbc.pool.OracleDataSource");
     }
 
     @Override

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ReflectionUtils.java
@@ -29,12 +29,8 @@ public final class ReflectionUtils {
      * @return new Java {@link Object} of the provided type
      */
     public static <T> T newInstance(String className) {
-        try {
-            Class clazz = Class.forName(className);
-            return newInstance(clazz);
-        } catch (ClassNotFoundException e) {
-            throw handleException(e);
-        }
+        Class clazz = getClass(className);
+        return newInstance(clazz);
     }
 
     /**
@@ -456,7 +452,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClass(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) Class.forName(className, false, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw handleException(e);
         }
@@ -473,7 +469,7 @@ public final class ReflectionUtils {
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getClassOrNull(String className) {
         try {
-            return (Class<T>) Class.forName(className);
+            return (Class<T>) getClass(className);
         } catch (Exception e) {
             return null;
         }

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/providers/OracleDataSourceProvider.java
@@ -35,11 +35,7 @@ public class OracleDataSourceProvider implements DataSourceProvider {
 
     @Override
     public Class<? extends DataSource> dataSourceClassName() {
-        try {
-            return (Class<? extends DataSource>) Class.forName("oracle.jdbc.pool.OracleDataSource");
-        } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(e);
-        }
+        return ReflectionUtils.getClass("oracle.jdbc.pool.OracleDataSource");
     }
 
     @Override


### PR DESCRIPTION
`hibernate-types` does not work with Quarkus (and possible also in other environments) as it is using `Class.forName(className)` at several places.

This PR changes this to use `Class.forName(className, false, Thread.currentThread().getContextClassLoader())` instead. 

See [this](https://github.com/quarkusio/quarkus/issues/6625) discussion on the Quarkus project with the rationale behind the change.

I've tried a local snapshot with the changes with Quarkus and Spring Boot and it works.

Note that locally `mvn clean test` gave a couple of failures, but I see these fail on `master` as well.