### PR TITLE
Add support for double arrays

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
@@ -1,0 +1,37 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.AbstractArrayType;
+import com.vladmihalcea.hibernate.type.array.internal.DoubleArrayTypeDescriptor;
+import com.vladmihalcea.hibernate.type.util.Configuration;
+
+/**
+ * Maps an {@code double[]} array on a PostgreSQL ARRAY type. Multidimensional arrays are supported as well, as explained in <a href="https://vladmihalcea.com/multidimensional-array-jpa-hibernate/">this article</a>.
+ * <p>
+ * For more details about how to use it, check out <a href=
+ * "https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this
+ * article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayType extends AbstractArrayType<double[]> {
+
+    public static final DoubleArrayType INSTANCE = new DoubleArrayType();
+
+    public DoubleArrayType() {
+        super(
+            new DoubleArrayTypeDescriptor()
+        );
+    }
+
+    public DoubleArrayType(Configuration configuration) {
+        super(
+            new DoubleArrayTypeDescriptor(),
+            configuration
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "double-array";
+    }
+}

--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
@@ -1,0 +1,17 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+/**
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayTypeDescriptor
+		extends AbstractArrayTypeDescriptor<double[]> {
+
+    public DoubleArrayTypeDescriptor() {
+		super(double[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+		return "double precision";
+    }
+}

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -18,6 +18,7 @@ import javax.persistence.Version;
     @TypeDef(name = "string-array", typeClass = StringArrayType.class),
     @TypeDef(name = "int-array", typeClass = IntArrayType.class),
     @TypeDef(name = "long-array", typeClass = LongArrayType.class),
+    @TypeDef(name = "double-array", typeClass = DoubleArrayType.class),
     @TypeDef(name = "date-array", typeClass = DateArrayType.class),
     @TypeDef(name = "timestamp-array", typeClass = TimestampArrayType.class),
     @TypeDef(name = "jsonb-node", typeClass = JsonNodeBinaryType.class),

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
@@ -1,0 +1,37 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.AbstractArrayType;
+import com.vladmihalcea.hibernate.type.array.internal.DoubleArrayTypeDescriptor;
+import com.vladmihalcea.hibernate.type.util.Configuration;
+
+/**
+ * Maps an {@code double[]} array on a PostgreSQL ARRAY type. Multidimensional arrays are supported as well, as explained in <a href="https://vladmihalcea.com/multidimensional-array-jpa-hibernate/">this article</a>.
+ * <p>
+ * For more details about how to use it, check out <a href=
+ * "https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this
+ * article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayType extends AbstractArrayType<double[]> {
+
+    public static final DoubleArrayType INSTANCE = new DoubleArrayType();
+
+    public DoubleArrayType() {
+        super(
+            new DoubleArrayTypeDescriptor()
+        );
+    }
+
+    public DoubleArrayType(Configuration configuration) {
+        super(
+            new DoubleArrayTypeDescriptor(),
+            configuration
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "double-array";
+    }
+}

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
@@ -1,0 +1,17 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+/**
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayTypeDescriptor
+		extends AbstractArrayTypeDescriptor<double[]> {
+
+    public DoubleArrayTypeDescriptor() {
+		super(double[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+		return "double precision";
+    }
+}

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -17,6 +17,7 @@ import javax.persistence.Version;
     @TypeDef(name = "string-array", typeClass = StringArrayType.class),
     @TypeDef(name = "int-array", typeClass = IntArrayType.class),
     @TypeDef(name = "long-array", typeClass = LongArrayType.class),
+    @TypeDef(name = "double-array", typeClass = DoubleArrayType.class),
     @TypeDef(name = "date-array", typeClass = DateArrayType.class),
     @TypeDef(name = "timestamp-array", typeClass = TimestampArrayType.class),
     @TypeDef(name = "json", typeClass = JsonStringType.class),

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
@@ -1,0 +1,37 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.AbstractArrayType;
+import com.vladmihalcea.hibernate.type.array.internal.DoubleArrayTypeDescriptor;
+import com.vladmihalcea.hibernate.type.util.Configuration;
+
+/**
+ * Maps an {@code double[]} array on a PostgreSQL ARRAY type. Multidimensional arrays are supported as well, as explained in <a href="https://vladmihalcea.com/multidimensional-array-jpa-hibernate/">this article</a>.
+ * <p>
+ * For more details about how to use it, check out <a href=
+ * "https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this
+ * article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayType extends AbstractArrayType<double[]> {
+
+    public static final DoubleArrayType INSTANCE = new DoubleArrayType();
+
+    public DoubleArrayType() {
+        super(
+            new DoubleArrayTypeDescriptor()
+        );
+    }
+
+    public DoubleArrayType(Configuration configuration) {
+        super(
+            new DoubleArrayTypeDescriptor(),
+            configuration
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "double-array";
+    }
+}

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
@@ -1,0 +1,17 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+/**
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayTypeDescriptor
+		extends AbstractArrayTypeDescriptor<double[]> {
+
+    public DoubleArrayTypeDescriptor() {
+		super(double[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+		return "double precision";
+    }
+}

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -17,6 +17,7 @@ import javax.persistence.Version;
     @TypeDef(name = "string-array", typeClass = StringArrayType.class),
     @TypeDef(name = "int-array", typeClass = IntArrayType.class),
     @TypeDef(name = "long-array", typeClass = LongArrayType.class),
+    @TypeDef(name = "double-array", typeClass = DoubleArrayType.class),
     @TypeDef(name = "date-array", typeClass = DateArrayType.class),
     @TypeDef(name = "timestamp-array", typeClass = TimestampArrayType.class),
     @TypeDef(name = "json", typeClass = JsonStringType.class),

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/DoubleArrayType.java
@@ -1,0 +1,37 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.AbstractArrayType;
+import com.vladmihalcea.hibernate.type.array.internal.DoubleArrayTypeDescriptor;
+import com.vladmihalcea.hibernate.type.util.Configuration;
+
+/**
+ * Maps an {@code double[]} array on a PostgreSQL ARRAY type. Multidimensional arrays are supported as well, as explained in <a href="https://vladmihalcea.com/multidimensional-array-jpa-hibernate/">this article</a>.
+ * <p>
+ * For more details about how to use it, check out <a href=
+ * "https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this
+ * article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayType extends AbstractArrayType<double[]> {
+
+    public static final DoubleArrayType INSTANCE = new DoubleArrayType();
+
+    public DoubleArrayType() {
+        super(
+            new DoubleArrayTypeDescriptor()
+        );
+    }
+
+    public DoubleArrayType(Configuration configuration) {
+        super(
+            new DoubleArrayTypeDescriptor(),
+            configuration
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "double-array";
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/DoubleArrayTypeDescriptor.java
@@ -1,0 +1,17 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+/**
+ * @author Vlad Mihalcea
+ */
+public class DoubleArrayTypeDescriptor
+		extends AbstractArrayTypeDescriptor<double[]> {
+
+    public DoubleArrayTypeDescriptor() {
+		super(double[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+		return "double precision";
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/model/BaseEntity.java
@@ -17,6 +17,7 @@ import javax.persistence.Version;
     @TypeDef(name = "string-array", typeClass = StringArrayType.class),
     @TypeDef(name = "int-array", typeClass = IntArrayType.class),
     @TypeDef(name = "long-array", typeClass = LongArrayType.class),
+    @TypeDef(name = "double-array", typeClass = DoubleArrayType.class),
     @TypeDef(name = "date-array", typeClass = DateArrayType.class),
     @TypeDef(name = "timestamp-array", typeClass = TimestampArrayType.class),
     @TypeDef(name = "json", typeClass = JsonStringType.class),


### PR DESCRIPTION
I don't have access to a system that supports docker right now (I only run Windows Home edition), so I didn't manage to run the unit tests. Hopefully the change doesn't break any tests. I used the `"double precision"` name for typing the double[] as it is done in PostgreSQL.