### PR TITLE
The ListArrayTypeDescriptor deepCopy method should not convert a List to an Java array

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ListArrayTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ListArrayTypeDescriptor.java
@@ -23,7 +23,7 @@ public class ListArrayTypeDescriptor extends AbstractArrayTypeDescriptor<Object>
             protected Object deepCopyNotNull(Object value) {
                 if (value instanceof List) {
                     Object[] array = ((List) value).toArray();
-                    return ArrayUtil.deepCopy(array);
+                    return Arrays.asList(ArrayUtil.deepCopy(array));
                 } else if (value.getClass().isArray()) {
                     Object[] array = (Object[]) value;
                     return ArrayUtil.deepCopy(array);
@@ -83,14 +83,13 @@ public class ListArrayTypeDescriptor extends AbstractArrayTypeDescriptor<Object>
         if (one == null || another == null) {
             return false;
         }
-        if(one instanceof Collection) {
-            one = ((Collection) one).toArray();
+        if (one instanceof Object[] && another instanceof Object[] ) {
+            return ArrayUtil.isEquals(one, another);
+        } else if (one instanceof List && another instanceof List) {
+            return ArrayUtil.isEquals(((List) one).toArray(), ((List) another).toArray());
+        } else {
+            throw new UnsupportedOperationException("The provided " + one + " and " + another + " are not Object[] or List!");
         }
-        if(another instanceof Collection) {
-            another = ((Collection) another).toArray();
-        }
-
-        return ArrayUtil.isEquals(one, another);
     }
 
     @Override


### PR DESCRIPTION
I got issues with casting Object[] from cache and List<> from runtime. That fixes solved my problem.
Used 
```
hibernate.cache.region.factory_class: com.hazelcast.hibernate.HazelcastCacheRegionFactory
hibernate_types_version=2.9.3
hibernate_version=5.4.10.Final
```
Please give me more advice how to describe issue for more.