### PR TITLE
Add Iso8601MonthType to save the 1-based value instead of the 0-based Enum ordinal for a java.time.Month entity attribute

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/MonthType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/MonthType.java
@@ -1,0 +1,44 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.AbstractHibernateType;
+import com.vladmihalcea.hibernate.type.basic.internal.MonthTypeDescriptor;
+import com.vladmihalcea.hibernate.type.util.Configuration;
+import org.hibernate.type.descriptor.sql.IntegerTypeDescriptor;
+
+import java.time.Month;
+
+/**
+ * Maps an {@link Month} object type to a {@code INT}  column type
+ * which is saved as value from 1 (January) to 12 (December).
+ *
+ * @author Martin Panzer
+ */
+public class MonthType extends AbstractHibernateType<Month> {
+
+    public static final MonthType INSTANCE = new MonthType();
+
+    public MonthType() {
+        super(
+                IntegerTypeDescriptor.INSTANCE,
+                MonthTypeDescriptor.INSTANCE
+        );
+    }
+
+    public MonthType(Configuration configuration) {
+        super(
+                IntegerTypeDescriptor.INSTANCE,
+                MonthTypeDescriptor.INSTANCE,
+                configuration
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "month";
+    }
+
+    @Override
+    protected boolean registerUnderJavaType() {
+        return true;
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/MonthTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/basic/internal/MonthTypeDescriptor.java
@@ -1,0 +1,59 @@
+package com.vladmihalcea.hibernate.type.basic.internal;
+
+import org.hibernate.type.descriptor.WrapperOptions;
+import org.hibernate.type.descriptor.java.AbstractTypeDescriptor;
+
+import java.time.Month;
+import java.util.Objects;
+
+/**
+ * @author Martin Panzer
+ */
+public class MonthTypeDescriptor
+        extends AbstractTypeDescriptor<Month> {
+
+    public static final MonthTypeDescriptor INSTANCE = new MonthTypeDescriptor();
+
+    public MonthTypeDescriptor() {
+        super(Month.class);
+    }
+
+    @Override
+    public boolean areEqual(Month one, Month another) {
+        return Objects.equals(one, another);
+    }
+
+    @Override
+    public String toString(Month value) {
+        return value.toString();
+    }
+
+    @Override
+    public Month fromString(String string) {
+        return Month.valueOf(string);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public <X> X unwrap(Month value, Class<X> type, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        if (Number.class.isAssignableFrom(type)) {
+            return (X) (Number) value.getValue();
+        }
+        throw unknownUnwrap(type);
+    }
+
+    @Override
+    public <X> Month wrap(X value, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number) {
+            int numericValue = ((Number) (value)).intValue();
+            return Month.of(numericValue);
+        }
+        throw unknownWrap(value.getClass());
+    }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/MonthTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/basic/MonthTest.java
@@ -1,0 +1,129 @@
+package com.vladmihalcea.hibernate.type.basic;
+
+import com.vladmihalcea.hibernate.type.util.AbstractMySQLIntegrationTest;
+import org.hibernate.Session;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.TypeDef;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Query;
+import javax.persistence.Table;
+import java.time.Month;
+import java.time.Year;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Martin Panzer
+ */
+public class MonthTest extends AbstractMySQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                Publisher.class
+        };
+    }
+
+    @Test
+    public void test() {
+        doInJPA(entityManager -> {
+            Publisher publisher = new Publisher();
+            publisher.setName("vladmihalcea.com");
+            publisher.setEstYear(Year.of(2013));
+            publisher.setSalesMonth(Month.NOVEMBER);
+
+            entityManager.persist(publisher);
+        });
+
+        doInJPA(entityManager -> {
+            Publisher publisher = entityManager
+            .unwrap(Session.class)
+            .bySimpleNaturalId(Publisher.class)
+            .load("vladmihalcea.com");
+
+            assertEquals(Year.of(2013), publisher.getEstYear());
+            assertEquals(Month.NOVEMBER, publisher.getSalesMonth());
+        });
+
+        doInJPA(entityManager -> {
+            Publisher book = entityManager
+            .createQuery(
+                "select p " +
+                "from Publisher p " +
+                "where " +
+                "   p.estYear = :estYear and " +
+                "   p.salesMonth = :salesMonth", Publisher.class)
+            .setParameter("estYear", Year.of(2013))
+            .setParameter("salesMonth", Month.NOVEMBER)
+            .getSingleResult();
+
+            assertEquals("vladmihalcea.com", book.getName());
+        });
+
+        doInJPA(entityManager -> {
+            Query query = entityManager.createNativeQuery("Select p.sales_month from publisher p where p.name = :name");
+            query.setParameter("name", "vladmihalcea.com");
+            Short result = (Short)query.getSingleResult();
+
+            Assert.assertEquals(11L, result.longValue());
+        });
+    }
+
+
+    @Entity(name = "Publisher")
+    @Table(name = "publisher")
+    @TypeDef(typeClass = MonthType.class, defaultForType = Month.class)
+    public static class Publisher {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @NaturalId
+        private String name;
+
+        @Column(name = "est_year")
+        private Year estYear;
+
+        @Column(name = "sales_month", columnDefinition = "smallint")
+        private Month salesMonth;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Year getEstYear() {
+            return estYear;
+        }
+
+        public void setEstYear(Year estYear) {
+            this.estYear = estYear;
+        }
+
+        public Month getSalesMonth() {
+            return salesMonth;
+        }
+
+        public void setSalesMonth(Month salesMonth) {
+            this.salesMonth = salesMonth;
+        }
+    }
+}


### PR DESCRIPTION
from 1 (January) to 12 (December)
closes #56