### PR TITLE
fix: infinity is a possible range value in PostgreSQL

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -31,6 +31,7 @@ public final class Range<T extends Comparable> implements Serializable {
     public static final int UPPER_EXCLUSIVE = 1 << 4;
     public static final int LOWER_INFINITE = (1 << 5) | LOWER_EXCLUSIVE;
     public static final int UPPER_INFINITE = (1 << 6) | UPPER_EXCLUSIVE;
+    public static final String INFINITE_VALUE = "infinity";
 
     private final T lower;
     private final T upper;
@@ -240,11 +241,11 @@ public final class Range<T extends Comparable> implements Serializable {
         String lowerStr = str.substring(1, delim);
         String upperStr = str.substring(delim + 1, str.length() - 1);
 
-        if (lowerStr.length() == 0) {
+        if (lowerStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(lowerStr)) {
             mask |= LOWER_INFINITE;
         }
 
-        if (upperStr.length() == 0) {
+        if (upperStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(upperStr)) {
             mask |= UPPER_INFINITE;
         }
 

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
@@ -32,6 +32,8 @@ public class RangeTest {
         assertThat(integerRange("[,]").hasUpperBound(), is(false));
         assertThat(integerRange("[,]").isUpperBoundClosed(), is(false));
         assertThat(integerRange("[,]").isLowerBoundClosed(), is(false));
+        assertThat(integerRange("(infinity,infinity)").lower(), is(nullValue()));
+        assertThat(integerRange("(infinity,infinity)").upper(), is(nullValue()));
 
         assertThat(integerRange("(-5,5]").isUpperBoundClosed(), is(true));
         assertThat(integerRange("(-5,5]").isLowerBoundClosed(), is(false));
@@ -46,8 +48,11 @@ public class RangeTest {
 
         assertThat(integerRange("(,)").contains(integerRange("(,)")), is(true));
         assertThat(integerRange("(5,)").contains(integerRange("(6,)")), is(true));
+        assertThat(integerRange("(5,infinity)").contains(integerRange("(6,infinity)")), is(true));
         assertThat(integerRange("(,5)").contains(integerRange("(,4)")), is(true));
+        assertThat(integerRange("(infinity,5)").contains(integerRange("(infinity,4)")), is(true));
         assertThat(integerRange("(,)").contains(integerRange("(6,)")), is(true));
-        assertThat(integerRange("(,)").contains(integerRange("(,6)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(6,infinity)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(infinity,6)")), is(true));
     }
 }

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -31,6 +31,7 @@ public final class Range<T extends Comparable> implements Serializable {
     public static final int UPPER_EXCLUSIVE = 1 << 4;
     public static final int LOWER_INFINITE = (1 << 5) | LOWER_EXCLUSIVE;
     public static final int UPPER_INFINITE = (1 << 6) | UPPER_EXCLUSIVE;
+    public static final String INFINITE_VALUE = "infinity";
 
     private final T lower;
     private final T upper;
@@ -240,11 +241,11 @@ public final class Range<T extends Comparable> implements Serializable {
         String lowerStr = str.substring(1, delim);
         String upperStr = str.substring(delim + 1, str.length() - 1);
 
-        if (lowerStr.length() == 0) {
+        if (lowerStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(lowerStr)) {
             mask |= LOWER_INFINITE;
         }
 
-        if (upperStr.length() == 0) {
+        if (upperStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(upperStr)) {
             mask |= UPPER_INFINITE;
         }
 

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
@@ -28,6 +28,8 @@ public class RangeTest {
 
         assertThat(integerRange("[,]").lower(), is(nullValue()));
         assertThat(integerRange("[,]").upper(), is(nullValue()));
+        assertThat(integerRange("(infinity,infinity)").lower(), is(nullValue()));
+        assertThat(integerRange("(infinity,infinity)").upper(), is(nullValue()));
         assertThat(integerRange("[,]").hasLowerBound(), is(false));
         assertThat(integerRange("[,]").hasUpperBound(), is(false));
         assertThat(integerRange("[,]").isUpperBoundClosed(), is(false));
@@ -49,5 +51,7 @@ public class RangeTest {
         assertThat(integerRange("(,5)").contains(integerRange("(,4)")), is(true));
         assertThat(integerRange("(,)").contains(integerRange("(6,)")), is(true));
         assertThat(integerRange("(,)").contains(integerRange("(,6)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(6,infinity)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(infinity,6)")), is(true));
     }
 }

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -31,6 +31,7 @@ public final class Range<T extends Comparable> implements Serializable {
     public static final int UPPER_EXCLUSIVE = 1 << 4;
     public static final int LOWER_INFINITE = (1 << 5) | LOWER_EXCLUSIVE;
     public static final int UPPER_INFINITE = (1 << 6) | UPPER_EXCLUSIVE;
+    public static final String INFINITE_VALUE = "infinity";
 
     private final T lower;
     private final T upper;
@@ -240,11 +241,11 @@ public final class Range<T extends Comparable> implements Serializable {
         String lowerStr = str.substring(1, delim);
         String upperStr = str.substring(delim + 1, str.length() - 1);
 
-        if (lowerStr.length() == 0) {
+        if (lowerStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(lowerStr)) {
             mask |= LOWER_INFINITE;
         }
 
-        if (upperStr.length() == 0) {
+        if (upperStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(upperStr)) {
             mask |= UPPER_INFINITE;
         }
 

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
@@ -28,6 +28,8 @@ public class RangeTest {
 
         assertThat(integerRange("[,]").lower(), is(nullValue()));
         assertThat(integerRange("[,]").upper(), is(nullValue()));
+        assertThat(integerRange("(infinity,infinity)").lower(), is(nullValue()));
+        assertThat(integerRange("(infinity,infinity)").upper(), is(nullValue()));
         assertThat(integerRange("[,]").hasLowerBound(), is(false));
         assertThat(integerRange("[,]").hasUpperBound(), is(false));
         assertThat(integerRange("[,]").isUpperBoundClosed(), is(false));
@@ -49,5 +51,7 @@ public class RangeTest {
         assertThat(integerRange("(,5)").contains(integerRange("(,4)")), is(true));
         assertThat(integerRange("(,)").contains(integerRange("(6,)")), is(true));
         assertThat(integerRange("(,)").contains(integerRange("(,6)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(6,infinity)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(infinity,6)")), is(true));
     }
 }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -44,6 +44,7 @@ public final class Range<T extends Comparable> implements Serializable {
     public static final int UPPER_EXCLUSIVE = 1 << 4;
     public static final int LOWER_INFINITE = (1 << 5) | LOWER_EXCLUSIVE;
     public static final int UPPER_INFINITE = (1 << 6) | UPPER_EXCLUSIVE;
+    public static final String INFINITE_VALUE = "infinity";
 
     private final T lower;
     private final T upper;
@@ -253,11 +254,11 @@ public final class Range<T extends Comparable> implements Serializable {
         String lowerStr = str.substring(1, delim);
         String upperStr = str.substring(delim + 1, str.length() - 1);
 
-        if (lowerStr.length() == 0) {
+        if (lowerStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(lowerStr)) {
             mask |= LOWER_INFINITE;
         }
 
-        if (upperStr.length() == 0) {
+        if (upperStr.length() == 0 || INFINITE_VALUE.equalsIgnoreCase(upperStr)) {
             mask |= UPPER_INFINITE;
         }
 

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeTypeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeTypeTest.java
@@ -31,6 +31,8 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
 
     private final Range<ZonedDateTime> tsTz = zonedDateTimeRange("[\"2007-12-03T10:15:30+01:00\",\"2008-12-03T10:15:30+01:00\"]");
 
+    private final Range<ZonedDateTime> infinityTsTz = zonedDateTimeRange("[\"2007-12-03T10:15:30+01:00\",infinity)");
+
     private final Range<LocalDate> dateRange = Range.localDateRange("[1992-01-13,1995-01-13)");
 
     @Override
@@ -51,6 +53,7 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
             restriction.setRangeBigDecimal(numeric);
             restriction.setRangeLocalDateTime(localDateTimeRange);
             restriction.setRangeZonedDateTime(tsTz);
+            restriction.setInfinityRangeZonedDateTime(infinityTsTz);
             restriction.setLocalDateRange(dateRange);
             entityManager.persist(restriction);
 
@@ -70,8 +73,10 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
 
             ZonedDateTime lower = tsTz.lower().withZoneSameInstant(zone);
             ZonedDateTime upper = tsTz.upper().withZoneSameInstant(zone);
-
             assertEquals(ar.getRangeZonedDateTime(), Range.closed(lower, upper));
+
+            lower = infinityTsTz.lower().withZoneSameInstant(zone);
+            assertEquals(ar.getInfinityRangeZonedDateTime(), Range.closedInfinite(lower));
         });
     }
 
@@ -93,6 +98,7 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
             assertNull(ar.getLocalDateTimeRange());
             assertNull(ar.getLocalDateRange());
             assertNull(ar.getRangeZonedDateTime());
+            assertNull(ar.getInfinityRangeZonedDateTime());
         });
     }
 
@@ -119,6 +125,9 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
 
         @Column(name = "r_tstzrange", columnDefinition = "tstzrange")
         private Range<ZonedDateTime> rangeZonedDateTime;
+
+        @Column(name = "r_infinitytstzrange", columnDefinition = "tstzrange")
+        private Range<ZonedDateTime> infinityRangeZonedDateTime;
 
         @Column(name = "r_daterange", columnDefinition = "daterange")
         private Range<LocalDate> localDateRange;
@@ -165,6 +174,14 @@ public class PostgreSQLRangeTypeTest extends AbstractPostgreSQLIntegrationTest {
 
         public void setRangeZonedDateTime(Range<ZonedDateTime> rangeZonedDateTime) {
             this.rangeZonedDateTime = rangeZonedDateTime;
+        }
+
+        public Range<ZonedDateTime> getInfinityRangeZonedDateTime() {
+            return infinityRangeZonedDateTime;
+        }
+
+        public void setInfinityRangeZonedDateTime(Range<ZonedDateTime> infinityRangeZonedDateTime) {
+            this.infinityRangeZonedDateTime = infinityRangeZonedDateTime;
         }
 
         public Range<LocalDate> getLocalDateRange() {

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
@@ -29,6 +29,8 @@ public class RangeTest {
 
         assertThat(integerRange("[,]").lower(), is(nullValue()));
         assertThat(integerRange("[,]").upper(), is(nullValue()));
+        assertThat(integerRange("(infinity,infinity)").lower(), is(nullValue()));
+        assertThat(integerRange("(infinity,infinity)").upper(), is(nullValue()));
         assertThat(integerRange("[,]").hasLowerBound(), is(false));
         assertThat(integerRange("[,]").hasUpperBound(), is(false));
         assertThat(integerRange("[,]").isUpperBoundClosed(), is(false));
@@ -47,9 +49,12 @@ public class RangeTest {
 
         assertThat(integerRange("(,)").contains(integerRange("(,)")), is(true));
         assertThat(integerRange("(5,)").contains(integerRange("(6,)")), is(true));
+        assertThat(integerRange("(5,infinity)").contains(integerRange("(6,infinity)")), is(true));
         assertThat(integerRange("(,5)").contains(integerRange("(,4)")), is(true));
+        assertThat(integerRange("(infinity,5)").contains(integerRange("(infinity,4)")), is(true));
         assertThat(integerRange("(,)").contains(integerRange("(6,)")), is(true));
-        assertThat(integerRange("(,)").contains(integerRange("(,6)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(6,infinity)")), is(true));
+        assertThat(integerRange("(infinity,infinity)").contains(integerRange("(infinity,6)")), is(true));
     }
     
     @Test
@@ -60,5 +65,6 @@ public class RangeTest {
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.1234-06,)"));
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.12345-06,)"));
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.123456-06,)"));
+    	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.123456-06,infinity)"));
     }
 }


### PR DESCRIPTION
This Pull Request is linked to the Issue #211 

It proves that `["2007-12-03T10:15:30+01:00",infinity)` is a valid tstzrange in Postgresql, and it permits, by changing the implementation of `Range.java`, to simply accept the `infinity` keyword into a range.