### PR TITLE
Make AbstractArrayTypeDescriptor#getArrayObjectClass public, fixes #214

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
@@ -33,7 +33,7 @@ public abstract class AbstractArrayTypeDescriptor<T>
         this.arrayObjectClass = arrayObjectClass;
     }
 
-    protected Class<T> getArrayObjectClass() {
+    public Class<T> getArrayObjectClass() {
         return arrayObjectClass;
     }
 

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
@@ -33,7 +33,7 @@ public abstract class AbstractArrayTypeDescriptor<T>
         this.arrayObjectClass = arrayObjectClass;
     }
 
-    protected Class<T> getArrayObjectClass() {
+    public Class<T> getArrayObjectClass() {
         return arrayObjectClass;
     }
 

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
@@ -33,7 +33,7 @@ public abstract class AbstractArrayTypeDescriptor<T>
         this.arrayObjectClass = arrayObjectClass;
     }
 
-    protected Class<T> getArrayObjectClass() {
+    public Class<T> getArrayObjectClass() {
         return arrayObjectClass;
     }
 

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/AbstractArrayTypeDescriptor.java
@@ -33,7 +33,7 @@ public abstract class AbstractArrayTypeDescriptor<T>
         this.arrayObjectClass = arrayObjectClass;
     }
 
-    protected Class<T> getArrayObjectClass() {
+    public Class<T> getArrayObjectClass() {
         return arrayObjectClass;
     }
 


### PR DESCRIPTION
It is useful for example when implementing `SQLFunctionTemplates` that need to know the result type, i.e.:

```java
metadataBuilder.applySqlFunction("ARRAY_ELEMENT_AT", new SQLFunctionTemplate(null, "?1[?2+1]") {
    @Override
    public Type getReturnType(Type argumentType, Mapping mapping) throws QueryException {
        if (argumentType == null) {
            return null;
        }

        TypeHelper typeHelper = ((SessionFactoryImpl) mapping).getTypeHelper();
        AbstractArrayTypeDescriptor javaTypeDescriptor = (AbstractArrayTypeDescriptor) ((AbstractArrayType) argumentType).getJavaTypeDescriptor();


        Class getJavaType = javaTypeDescriptor.getArrayObjectClass(); // access required here
        Class componentType = getJavaType.getComponentType();
        BasicType basic = typeHelper.basic(componentType);
        return basic;
    }
});
```

Fixes #214