### PR TITLE
Allow StringArrayType to work on HSQLDB

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
@@ -206,7 +206,7 @@ public class ArrayUtil {
             if(arrayClass.isInstance(originalArray)) {
                 return (T) originalArray;
             } else {
-                throw new UnsupportedOperationException("Cannot transform array :" + Arrays.toString(originalArray) + " to type: " + arrayClass);
+                return (T) Arrays.copyOf(originalArray, originalArray.length, (Class) arrayClass);
             }
         }
     }


### PR DESCRIPTION
Without this change, I was getting the unsupported operation exception complaining that the originalArray was of type Object[].