### PR TITLE
Allow the custom ObjectMapper be used for JSON serialization

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -28,6 +28,14 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
             }
         }
 
+        if (value instanceof Map && !((Map) value).isEmpty()) {
+            Map.Entry firstElement = (Map.Entry) ((Map) value).entrySet().iterator().next();
+            if (!(firstElement.getKey() instanceof Serializable)
+                    || !(firstElement.getValue() instanceof Serializable)) {
+                return (T) objectMapperWrapper.fromBytes(objectMapperWrapper.toBytes(value), (Class<T>) value.getClass());
+            }
+        }
+
         return value instanceof Serializable ?
                 (T) SerializationHelper.clone((Serializable) value) :
                 objectMapperWrapper.fromBytes(objectMapperWrapper.toBytes(value), (Class<T>) value.getClass());


### PR DESCRIPTION
When using a custom JSON serializer, by setting the property `hibernate.types.json.serializer` used in `com.vladmihalcea.hibernate.type.util.Configuration`, the default mechanism doesn't use the custom serializer for `Map` types (HashMap, ...).

The current code handles Collection-based types but fallbacks on the default behaviour for other types.
The default behaviour check if the value to serialize implements `Serializable` (and HashMap does), then the underlying Map values aren't handle by the custom serializer because already in the java native `clone()` behaviour.