### PR TITLE
Allow JSON Types to handle parameterized entity attribute type variables

### DIFF
--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.sql.Blob;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -165,8 +166,10 @@ public class JsonTypeDescriptor
 
     private Class typeToClass() {
         Type classType = type;
-        if(type instanceof ParameterizedType) {
+        if (type instanceof ParameterizedType) {
             classType = ((ParameterizedType) type).getRawType();
+        } else if (type instanceof TypeVariable) {
+            classType = ((TypeVariable) type).getGenericDeclaration().getClass();
         }
         return (Class) classType;
     }

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.sql.Blob;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -165,8 +166,10 @@ public class JsonTypeDescriptor
 
     private Class typeToClass() {
         Type classType = type;
-        if(type instanceof ParameterizedType) {
+        if (type instanceof ParameterizedType) {
             classType = ((ParameterizedType) type).getRawType();
+        } else if (type instanceof TypeVariable) {
+            classType = ((TypeVariable) type).getGenericDeclaration().getClass();
         }
         return (Class) classType;
     }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.sql.Blob;
 import java.sql.SQLException;
 import java.util.Collection;
@@ -167,6 +168,8 @@ public class JsonTypeDescriptor
         Type classType = type;
         if (type instanceof ParameterizedType) {
             classType = ((ParameterizedType) type).getRawType();
+        } else if (type instanceof TypeVariable) {
+            classType = ((TypeVariable) type).getGenericDeclaration().getClass();
         }
         return (Class) classType;
     }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
@@ -10,6 +10,7 @@ import org.hibernate.usertype.DynamicParameterizedType;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Properties;
@@ -83,6 +84,8 @@ public class PostgreSQLTSVectorTypeDescriptor extends AbstractTypeDescriptor<Obj
         Type classType = type;
         if (type instanceof ParameterizedType) {
             classType = ((ParameterizedType) type).getRawType();
+        } else if (type instanceof TypeVariable) {
+            classType = ((TypeVariable) type).getGenericDeclaration().getClass();
         }
         return (Class) classType;
     }


### PR DESCRIPTION
Handle TypeVariable type

For instance:

```java
@Entity
@TypeDef(name = ColumnTypes.JSON_BINARY, typeClass = JsonBinaryType.class)
@DiscriminatorColumn(name = Columns.TYPE)
public class MyClass<T> {
  @Type(type = ColumnTypes.JSON_BINARY)
  @Column(columnDefinition = ColumnTypes.JSON_BINARY)
  private T something;
}
```