### PR TITLE
Use non-null entries for guessing the content type of maps

### DIFF
--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -1,13 +1,16 @@
 package com.vladmihalcea.hibernate.type.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ObjectMapperJsonSerializerTest {
 
@@ -82,6 +85,35 @@ public class ObjectMapperJsonSerializerTest {
         assertNotSame(original, cloned);
     }
 
+    @Test
+    public void should_clone_map_with_null_value() {
+        Map<String, Object> original = new HashMap<String, Object>();
+        original.put("null", null);
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_non_serializable_value_with_null_value() {
+        Map<String, NonSerializableObject> original = new LinkedHashMap<String, NonSerializableObject>();
+        original.put("null", null);
+        original.put("key", new NonSerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_serializable_key_and_value_with_null() {
+        Map<String, SerializableObject> original = new LinkedHashMap<String, SerializableObject>();
+        original.put("null", null);
+        original.put("key", new SerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
     private static class SerializableObject implements Serializable {
         private final String value;
 
@@ -95,8 +127,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             SerializableObject that = (SerializableObject) o;
 
@@ -127,8 +161,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             NonSerializableObject that = (NonSerializableObject) o;
 

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -1,13 +1,16 @@
 package com.vladmihalcea.hibernate.type.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ObjectMapperJsonSerializerTest {
 
@@ -82,6 +85,35 @@ public class ObjectMapperJsonSerializerTest {
         assertNotSame(original, cloned);
     }
 
+    @Test
+    public void should_clone_map_with_null_value() {
+        Map<String, Object> original = new HashMap<String, Object>();
+        original.put("null", null);
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_non_serializable_value_with_null_value() {
+        Map<String, NonSerializableObject> original = new LinkedHashMap<String, NonSerializableObject>();
+        original.put("null", null);
+        original.put("key", new NonSerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_serializable_key_and_value_with_null() {
+        Map<String, SerializableObject> original = new LinkedHashMap<String, SerializableObject>();
+        original.put("null", null);
+        original.put("key", new SerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
     private static class SerializableObject implements Serializable {
         private final String value;
 
@@ -95,8 +127,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             SerializableObject that = (SerializableObject) o;
 
@@ -127,8 +161,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             NonSerializableObject that = (NonSerializableObject) o;
 

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -1,13 +1,16 @@
 package com.vladmihalcea.hibernate.type.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ObjectMapperJsonSerializerTest {
 
@@ -82,6 +85,35 @@ public class ObjectMapperJsonSerializerTest {
         assertNotSame(original, cloned);
     }
 
+    @Test
+    public void should_clone_map_with_null_value() {
+        Map<String, Object> original = new HashMap<String, Object>();
+        original.put("null", null);
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_non_serializable_value_with_null_value() {
+        Map<String, NonSerializableObject> original = new LinkedHashMap<String, NonSerializableObject>();
+        original.put("null", null);
+        original.put("key", new NonSerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_serializable_key_and_value_with_null() {
+        Map<String, SerializableObject> original = new LinkedHashMap<String, SerializableObject>();
+        original.put("null", null);
+        original.put("key", new SerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
     private static class SerializableObject implements Serializable {
         private final String value;
 
@@ -95,8 +127,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             SerializableObject that = (SerializableObject) o;
 
@@ -127,8 +161,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             NonSerializableObject that = (NonSerializableObject) o;
 

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -1,13 +1,16 @@
 package com.vladmihalcea.hibernate.type.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import org.junit.Test;
 
 import java.io.Serializable;
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ObjectMapperJsonSerializerTest {
 
@@ -82,6 +85,35 @@ public class ObjectMapperJsonSerializerTest {
         assertNotSame(original, cloned);
     }
 
+    @Test
+    public void should_clone_map_with_null_value() {
+        Map<String, Object> original = new HashMap<>();
+        original.put("null", null);
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_non_serializable_value_with_null_value() {
+        Map<String, NonSerializableObject> original = new LinkedHashMap<>();
+        original.put("null", null);
+        original.put("key", new NonSerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_map_of_serializable_key_and_value_with_null() {
+        Map<String, SerializableObject> original = new LinkedHashMap<>();
+        original.put("null", null);
+        original.put("key", new SerializableObject("value"));
+        Object cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
     private static class SerializableObject implements Serializable {
         private final String value;
 
@@ -95,8 +127,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             SerializableObject that = (SerializableObject) o;
 
@@ -127,8 +161,10 @@ public class ObjectMapperJsonSerializerTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             NonSerializableObject that = (NonSerializableObject) o;
 


### PR DESCRIPTION
It may happen that a map contains keys associated with null values, when these maps are cloned
a NullPointerException is thrown. This was bug introduced with #220. We fix this by only
considering non-null values in the map to guess the content-type for the cloning of
non-serializable maps.

/cc @lounagen 