### PR TITLE
Always call ObjectMapper in JsonTypeDescriptor::fromString to strip String quotes

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -103,9 +103,6 @@ public class JsonTypeDescriptor
 
     @Override
     public Object fromString(String string) {
-        if (String.class.isAssignableFrom(typeToClass())) {
-            return string;
-        }
         return objectMapperWrapper.fromString(string, type);
     }
 


### PR DESCRIPTION
In order to strip quotes from a JSON string, `ObjectMapper` is always called in `JsonTypeDescriptor.java::fromString`.

I had trouble getting the tests to work (Docker is running both PostgreSQL and MySQL) but comparing before and after I went from 18 failed to 17 failed.

The new test `PostgreSQLJsonStringPropertyTest::testStringValue` is now passing.

The conditional that avoids the `ObjectMapper` call looks to be an optimisation, so the risk here is perhaps reduced but I would feel a lot better if I could get all the tests working before this change.

Attempt to address request in https://github.com/vladmihalcea/hibernate-types/issues/251