### PR TITLE
Fix for ClassCastException during debug mode

### DIFF
--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/array/internal/ArrayUtil.java
@@ -119,6 +119,8 @@ public class ArrayUtil {
             return array;
         } else if (originalArray instanceof List) {
             return ((List) originalArray).toArray();
+        } else if (originalArray instanceof Set) {
+            return ((Set) originalArray).toArray();
         } else {
             return (Object[]) originalArray;
         }


### PR DESCRIPTION
Caused by: java.lang.ClassCastException: java.util.HashSet cannot be cast to [Ljava.lang.Object;
	at com.vladmihalcea.hibernate.type.array.internal.ArrayUtil.wrapArray(ArrayUtil.java:123) ~[hibernate-types-52-2.9.11.jar:?]
	at com.vladmihalcea.hibernate.type.array.internal.AbstractArrayTypeDescriptor.toString(AbstractArrayTypeDescriptor.java:69) ~[hibernate-types-52-2.9.11.jar:?]
	at com.vladmihalcea.hibernate.type.array.internal.AbstractArrayTypeDescriptor.extractLoggableRepresentation(AbstractArrayTypeDescriptor.java:79) ~[hibernate-types-52-2.9.11.jar:?]
	at org.hibernate.type.AbstractStandardBasicType.toLoggableString(AbstractStandardBasicType.java:293) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.internal.util.EntityPrinter.toString(EntityPrinter.java:73) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.internal.util.EntityPrinter.toString(EntityPrinter.java:117) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.event.internal.AbstractFlushingEventListener.logFlushResults(AbstractFlushingEventListener.java:129) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.event.internal.AbstractFlushingEventListener.flushEverythingToExecutions(AbstractFlushingEventListener.java:105) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:38) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1454) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.internal.SessionImpl.managedFlush(SessionImpl.java:511) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.internal.SessionImpl.flushBeforeTransactionCompletion(SessionImpl.java:3290) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.internal.SessionImpl.beforeTransactionCompletion(SessionImpl.java:2486) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.beforeTransactionCompletion(JdbcCoordinatorImpl.java:473) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.beforeCompletionCallback(JdbcResourceLocalTransactionCoordinatorImpl.java:178) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.access$300(JdbcResourceLocalTransactionCoordinatorImpl.java:39) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:271) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:104) ~[hibernate-core-5.3.10.Final.jar:5.3.10.Final]
	at org.springframework.orm.jpa.JpaTransactionManager.doCommit(JpaTransactionManager.java:532) ~[spring-orm-5.1.7.RELEASE.jar:5.1.7.RELEASE]
