### PR TITLE
Fixed pattern for DateTimeFormatter

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -40,7 +40,7 @@ public final class Range<T extends Comparable> implements Serializable {
 
     public static final String INFINITY = "infinity";
 
-    private static final DateTimeFormatter LOCAL_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS]");
+    private static final DateTimeFormatter LOCAL_DATE_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS][.SSSSS][.SSSS][.SSS][.SS][.S]");
 
     private static final DateTimeFormatter ZONE_DATE_TIME = new DateTimeFormatterBuilder()
         .appendPattern("yyyy-MM-dd HH:mm:ss")


### PR DESCRIPTION
At present, the DateTimeFormatter in the range class only works if the time does not contain anything beyond the second precision of it contains all the six digits. 

So let's say if I want to store the time "2020-01-01 01:01:01.111"(up to the millisecond level) within a tsrange, deserialization to the Range object fails. Also, Postgres seems to truncate the trailing zeroes in a given time making all the combinations possible.

Sample code to recreate the issue -

```
public static void main(String []args){
    System.out.println( DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss[.SSSSSS]").parse("2020-01-01 01:01:01.111"));
}
```