### PR TITLE
Use parameter delimiter to join string and remove hardcoding

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
@@ -30,7 +30,7 @@ public class StringUtils {
             if(first) {
                 first = false;
             } else {
-                builder.append(LINE_SEPARATOR);
+                builder.append(delimiter);
             }
             builder.append(element);
         }

--- a/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
+++ b/hibernate-types-4/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
@@ -1,0 +1,20 @@
+package com.vladmihalcea.hibernate.type.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void should_join_string_with_delimiter(){
+
+        // GIVEN
+        String delimiter = ",";
+
+        // WHEN
+        final String joinedString = StringUtils.join(delimiter, "Oracle", "PostgreSQL", "MySQL", "SQL Server");
+
+        // THEN
+        Assert.assertEquals("Oracle,PostgreSQL,MySQL,SQL Server", joinedString);
+    }
+}

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
@@ -30,7 +30,7 @@ public class StringUtils {
             if(first) {
                 first = false;
             } else {
-                builder.append(LINE_SEPARATOR);
+                builder.append(delimiter);
             }
             builder.append(element);
         }

--- a/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
+++ b/hibernate-types-43/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
@@ -1,0 +1,20 @@
+package com.vladmihalcea.hibernate.type.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void should_join_string_with_delimiter(){
+
+        // GIVEN
+        String delimiter = ",";
+
+        // WHEN
+        final String joinedString = StringUtils.join(delimiter, "Oracle", "PostgreSQL", "MySQL", "SQL Server");
+
+        // THEN
+        Assert.assertEquals("Oracle,PostgreSQL,MySQL,SQL Server", joinedString);
+    }
+}

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
@@ -30,7 +30,7 @@ public class StringUtils {
             if(first) {
                 first = false;
             } else {
-                builder.append(LINE_SEPARATOR);
+                builder.append(delimiter);
             }
             builder.append(element);
         }

--- a/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
+++ b/hibernate-types-5/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
@@ -1,0 +1,20 @@
+package com.vladmihalcea.hibernate.type.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void should_join_string_with_delimiter(){
+
+        // GIVEN
+        String delimiter = ",";
+
+        // WHEN
+        final String joinedString = StringUtils.join(delimiter, "Oracle", "PostgreSQL", "MySQL", "SQL Server");
+
+        // THEN
+        Assert.assertEquals("Oracle,PostgreSQL,MySQL,SQL Server", joinedString);
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/StringUtils.java
@@ -30,7 +30,7 @@ public class StringUtils {
             if(first) {
                 first = false;
             } else {
-                builder.append(LINE_SEPARATOR);
+                builder.append(delimiter);
             }
             builder.append(element);
         }

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/StringUtilsTest.java
@@ -1,0 +1,20 @@
+package com.vladmihalcea.hibernate.type.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void should_join_string_with_delimiter(){
+
+        // GIVEN
+        String delimiter = ",";
+
+        // WHEN
+        final String joinedString = StringUtils.join(delimiter, "Oracle", "PostgreSQL", "MySQL", "SQL Server");
+
+        // THEN
+        Assert.assertEquals("Oracle,PostgreSQL,MySQL,SQL Server", joinedString);
+    }
+}


### PR DESCRIPTION
Use parameter delimiter to join string and remove hardcoding of LINE_SEPRATOR

https://github.com/vladmihalcea/hibernate-types/issues/302#issue-817856475