### PR TITLE
Add support for half-hour time zones in ZonedDateTime

### DIFF
--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -54,7 +54,7 @@ public final class Range<T extends Comparable> implements Serializable {
         .appendPattern(".")
         .appendFraction(ChronoField.NANO_OF_SECOND, 1, 6, false)
         .optionalEnd()
-        .appendPattern("X")
+        .appendOffset("+HH:mm", "")
         .toFormatter();
 
     private final T lower;
@@ -162,7 +162,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (a, +∞) = {x | x > a}
+     *     (a, +âˆž) = {x | x > a}
      * }</pre>
      *
      * @param lower The lower bound, never null.
@@ -181,7 +181,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     [a, +∞) = {x | x >= a}
+     *     [a, +âˆž) = {x | x >= a}
      * }</pre>
      *
      * @param lower The lower bound, never null.
@@ -200,7 +200,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (-∞, b) = {x | x < b}
+     *     (-âˆž, b) = {x | x < b}
      * }</pre>
      *
      * @param upper The upper bound, never null.
@@ -219,7 +219,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (-∞, b] = {x | x =< b}
+     *     (-âˆž, b] = {x | x =< b}
      * }</pre>
      *
      * @param upper The upper bound, never null.
@@ -238,7 +238,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (-∞, +∞) = ℝ
+     *     (-âˆž, +âˆž) = â„�
      * }</pre>
      *
      * @param cls The range class, never null.

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -162,7 +162,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (a, +âˆž) = {x | x > a}
+     *     (a, +∞) = {x | x > a}
      * }</pre>
      *
      * @param lower The lower bound, never null.
@@ -181,7 +181,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     [a, +âˆž) = {x | x >= a}
+     *     [a, +∞) = {x | x >= a}
      * }</pre>
      *
      * @param lower The lower bound, never null.
@@ -200,7 +200,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (-âˆž, b) = {x | x < b}
+     *     (-∞, b) = {x | x < b}
      * }</pre>
      *
      * @param upper The upper bound, never null.
@@ -219,7 +219,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (-âˆž, b] = {x | x =< b}
+     *     (-∞, b] = {x | x =< b}
      * }</pre>
      *
      * @param upper The upper bound, never null.
@@ -238,7 +238,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * <p>
      * The mathematical equivalent will be:
      * <pre>{@code
-     *     (-âˆž, +âˆž) = â„�
+     *     (-∞, +∞) = ℝ
      * }</pre>
      *
      * @param cls The range class, never null.

--- a/hibernate-types-55/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
+++ b/hibernate-types-55/src/test/java/com/vladmihalcea/hibernate/type/range/RangeTest.java
@@ -71,6 +71,7 @@ public class RangeTest {
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.1234-06,)"));
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.12345-06,)"));
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.123456-06,)"));
+    	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.123456+05:30,)"));
     	assertNotNull(Range.zonedDateTimeRange("[2019-03-27 16:33:10.123456-06,infinity)"));
     }
 }


### PR DESCRIPTION
- "X" pattern was creating issue, as it was not matching +05:30, it was only matching +05
- Offset "+HH:mm" pattern is suggested as it matches both +05:30 and +05
- Warning: Offset "+HH:mm" pattern will not match +0530, hope PostgesSQL will not return so

Refer: https://github.com/vladmihalcea/hibernate-types/issues/329