### PR TITLE
Update supported Hibernate versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The Hibernate Types repository gives you extra types and general purpose utilities that are not supported by the Hibernate ORM core. 
 
-The main advantage of this project is that it supports a broad range of Hibernate versions, spanning from Hibernate 4.1 to Hibernate 5.4.
+The main advantage of this project is that it supports a broad range of Hibernate versions, spanning from Hibernate 4.1 to Hibernate 5.5.
 
 ### Features
 


### PR DESCRIPTION
Below, dependencies for up to Hibernate 5.5 are mentioned. The versions should be reflected at the beginning.