### PR TITLE
Support java.sql.Date[] to java.time.LocalDate[] retrieval

### DIFF
--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/array/LocalDateArrayType.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/array/LocalDateArrayType.java
@@ -1,0 +1,56 @@
+package com.vladmihalcea.hibernate.type.array;
+
+import com.vladmihalcea.hibernate.type.array.internal.AbstractArrayType;
+import com.vladmihalcea.hibernate.type.array.internal.LocalDateArrayTypeDescriptor;
+import com.vladmihalcea.hibernate.type.util.Configuration;
+import com.vladmihalcea.hibernate.type.util.ParameterizedParameterType;
+import org.hibernate.usertype.DynamicParameterizedType;
+
+import java.util.Properties;
+
+/**
+ *
+ * Maps a {@code java.Time.LocalDate[]} array on a PostgreSQL date[] ARRAY type. Multidimensional arrays are
+ * supported as well, as
+ * explained in <a href="https://vladmihalcea.com/multidimensional-array-jpa-hibernate/">this article</a>.
+ * <p>
+ * For more details about how to use it, check out
+ * <a href="https://vladmihalcea.com/how-to-map-java-and-sql-arrays-with-jpa-and-hibernate/">this
+ * article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
+ *
+ * @author Andrew Lazarus, based on DateArrayType by Guillaume Briand
+ *
+ */
+
+public class LocalDateArrayType extends AbstractArrayType<java.time.LocalDate[]>  {
+
+    public static final com.vladmihalcea.hibernate.type.array.LocalDateArrayType INSTANCE =
+            new com.vladmihalcea.hibernate.type.array.LocalDateArrayType();
+
+    public LocalDateArrayType(){
+        super(
+                new LocalDateArrayTypeDescriptor()
+        );
+    }
+
+    public LocalDateArrayType(Configuration configuration) {
+        super(
+                new LocalDateArrayTypeDescriptor(), configuration
+        );
+    }
+
+    public LocalDateArrayType(Class arrayClass) {
+        this();
+        Properties parameters = new Properties();
+        parameters.put(DynamicParameterizedType.PARAMETER_TYPE, new ParameterizedParameterType(arrayClass));
+        setParameterValues(parameters);
+    }
+
+    public LocalDateArrayType(org.hibernate.type.spi.TypeBootstrapContext typeBootstrapContext) {
+        this(new Configuration(typeBootstrapContext.getConfigurationSettings()));
+    }
+
+    public String getName() {
+        return "localdate-array";
+    }
+}

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/array/internal/LocalDateArrayTypeDescriptor.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/array/internal/LocalDateArrayTypeDescriptor.java
@@ -1,0 +1,14 @@
+package com.vladmihalcea.hibernate.type.array.internal;
+
+public class LocalDateArrayTypeDescriptor extends AbstractArrayTypeDescriptor<java.time.LocalDate[]>  {
+
+
+    public LocalDateArrayTypeDescriptor() {
+        super(java.time.LocalDate[].class);
+    }
+
+    @Override
+    protected String getSqlArrayType() {
+        return "date";
+    }
+}


### PR DESCRIPTION
Storing LocalDate[] to a (Postgres, at least) DB
worked with existing code. Read did not.

Also extended attempt to copy other types of
received arrays to try harder before failing.

[Notes: Java 8 is long gone from my build system, making it difficult
to build and use this project in IntelliJ, at least for me. I created
a jar by hand, built with no errors, and it worked correctly
for my use case, which is given in the title. But the JUnit
tests have _not_ been run on the modified code.]