### PR TITLE
implement OffsetDateTimeObjectMapperSupplier

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeDeserializer.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeDeserializer.java
@@ -1,0 +1,27 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+public class OffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
+
+  @Override
+  public OffsetDateTime deserialize(JsonParser jsonParser,
+      DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+      if (jsonParser.getText() != null) {
+          return OffsetDateTime.parse(jsonParser.getText(), ISO_OFFSET_DATE_TIME);
+      }
+      return null;
+  }
+
+  @Override
+  public Class<OffsetDateTime> handledType() {
+    return OffsetDateTime.class;
+  }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplier.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplier.java
@@ -1,0 +1,32 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.vladmihalcea.hibernate.type.util.ObjectMapperSupplier;
+import java.time.OffsetDateTime;
+
+/**
+ * Jackson Object Mapper for jsonb hibernate type to persist a java.time.OffsetDateTime without losing timezone.
+ *
+ * to register this mapper create <code>hibernate-types.properties</code> file and add the following property:
+ * <code>hibernate.types.jackson.object.mapper=com.vladmihalcea.hibernate.type.util.objectmapper.OffsetDateTimeObjectMapperSupplier</code>
+ */
+public class OffsetDateTimeObjectMapperSupplier implements ObjectMapperSupplier {
+
+    private static final String OFFSET_DATE_TIME_MODULE_NAME = "OffsetDateTimeModule";
+
+    private static final Version OFFSET_DATE_TIME_MODULE_VERSION = new Version(1,0,0, null, null, null);
+
+    @Override
+    public ObjectMapper get() {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+        SimpleModule offsetDateTimeModule = new SimpleModule(OFFSET_DATE_TIME_MODULE_NAME, OFFSET_DATE_TIME_MODULE_VERSION);
+        offsetDateTimeModule.addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer());
+        offsetDateTimeModule.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
+        objectMapper.registerModule(offsetDateTimeModule);
+
+        return objectMapper;
+    }
+}

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeSerializer.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeSerializer.java
@@ -1,0 +1,32 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+/**
+ * Jackson Json Serializer which transforms an java.time.OffsetDateTime to String in Format java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME .
+ *
+ * With this format the current timezone of OffsetDateTime is not lost.
+ */
+public class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+
+  @Override
+  public void serialize(OffsetDateTime offsetDateTime, JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider) throws IOException {
+      if (offsetDateTime == null) {
+          jsonGenerator.writeNull();
+      } else {
+          jsonGenerator.writeString(offsetDateTime.format(ISO_OFFSET_DATE_TIME));
+      }
+  }
+
+  @Override
+  public Class<OffsetDateTime> handledType() {
+      return OffsetDateTime.class;
+  }
+}

--- a/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplierTest.java
+++ b/hibernate-types-52/src/test/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplierTest.java
@@ -1,0 +1,56 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class OffsetDateTimeObjectMapperSupplierTest {
+
+    private ObjectMapper offsetDateTimeMapper = new OffsetDateTimeObjectMapperSupplier().get();
+
+    @Test
+    public void should_convert_OffsetDateTime_to_String() throws JsonProcessingException {
+        OffsetDateTime currentTime = OffsetDateTime.of(2021, 12, 15, 10, 25, 17, 123456, ZoneOffset.of("+01:00"));
+        String expectedResult = "\"2021-12-15T10:25:17.000123456+01:00\"";
+
+        String actualResult = offsetDateTimeMapper.writeValueAsString(currentTime);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void should_write_null_Object_from_OffsetDateTime_as_null_String() throws JsonProcessingException {
+        OffsetDateTime currentTime = null;
+        String expectedResult = "null";
+
+        String actualResult = offsetDateTimeMapper.writeValueAsString(currentTime);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void should_convert_a_String_to_OffsetDateTime() throws JsonProcessingException {
+        String currentTime = "\"2021-12-15T10:25:17.000123456+01:00\"";
+        OffsetDateTime expectedResult = OffsetDateTime.of(2021, 12, 15, 10, 25, 17, 123456, ZoneOffset.of("+01:00"));
+
+        OffsetDateTime actualResult = offsetDateTimeMapper.readValue(currentTime, OffsetDateTime.class);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+
+    @Test
+    public void should_convert_a_null_String_to_a_null_OffsetDateTime() throws JsonProcessingException {
+        String currentTime = "null";
+
+        OffsetDateTime actualResult = offsetDateTimeMapper.readValue(currentTime, OffsetDateTime.class);
+
+        assertNull(actualResult);
+    }
+
+}

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeDeserializer.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeDeserializer.java
@@ -1,0 +1,27 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+public class OffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
+
+  @Override
+  public OffsetDateTime deserialize(JsonParser jsonParser,
+      DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+      if (jsonParser.getText() != null) {
+          return OffsetDateTime.parse(jsonParser.getText(), ISO_OFFSET_DATE_TIME);
+      }
+      return null;
+  }
+
+  @Override
+  public Class<OffsetDateTime> handledType() {
+    return OffsetDateTime.class;
+  }
+}

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplier.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplier.java
@@ -1,0 +1,32 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.vladmihalcea.hibernate.type.util.ObjectMapperSupplier;
+import java.time.OffsetDateTime;
+
+/**
+ * Jackson Object Mapper for jsonb hibernate type to persist a java.time.OffsetDateTime without losing timezone.
+ *
+ * to register this mapper create <code>hibernate-types.properties</code> file and add the following property:
+ * <code>hibernate.types.jackson.object.mapper=com.vladmihalcea.hibernate.type.util.objectmapper.OffsetDateTimeObjectMapperSupplier</code>
+ */
+public class OffsetDateTimeObjectMapperSupplier implements ObjectMapperSupplier {
+
+    private static final String OFFSET_DATE_TIME_MODULE_NAME = "OffsetDateTimeModule";
+
+    private static final Version OFFSET_DATE_TIME_MODULE_VERSION = new Version(1,0,0, null, null, null);
+
+    @Override
+    public ObjectMapper get() {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+        SimpleModule offsetDateTimeModule = new SimpleModule(OFFSET_DATE_TIME_MODULE_NAME, OFFSET_DATE_TIME_MODULE_VERSION);
+        offsetDateTimeModule.addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer());
+        offsetDateTimeModule.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
+        objectMapper.registerModule(offsetDateTimeModule);
+
+        return objectMapper;
+    }
+}

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeSerializer.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeSerializer.java
@@ -1,0 +1,32 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+/**
+ * Jackson Json Serializer which transforms an java.time.OffsetDateTime to String in Format java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME .
+ *
+ * With this format the current timezone of OffsetDateTime is not lost.
+ */
+public class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+
+  @Override
+  public void serialize(OffsetDateTime offsetDateTime, JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider) throws IOException {
+      if (offsetDateTime == null) {
+          jsonGenerator.writeNull();
+      } else {
+          jsonGenerator.writeString(offsetDateTime.format(ISO_OFFSET_DATE_TIME));
+      }
+  }
+
+  @Override
+  public Class<OffsetDateTime> handledType() {
+      return OffsetDateTime.class;
+  }
+}

--- a/hibernate-types-55/src/test/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplierTest.java
+++ b/hibernate-types-55/src/test/java/com/vladmihalcea/hibernate/type/util/objectmapper/OffsetDateTimeObjectMapperSupplierTest.java
@@ -1,0 +1,56 @@
+package com.vladmihalcea.hibernate.type.util.objectmapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class OffsetDateTimeObjectMapperSupplierTest {
+
+    private ObjectMapper offsetDateTimeMapper = new OffsetDateTimeObjectMapperSupplier().get();
+
+    @Test
+    public void should_convert_OffsetDateTime_to_String() throws JsonProcessingException {
+        OffsetDateTime currentTime = OffsetDateTime.of(2021, 12, 15, 10, 25, 17, 123456, ZoneOffset.of("+01:00"));
+        String expectedResult = "\"2021-12-15T10:25:17.000123456+01:00\"";
+
+        String actualResult = offsetDateTimeMapper.writeValueAsString(currentTime);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void should_write_null_Object_from_OffsetDateTime_as_null_String() throws JsonProcessingException {
+        OffsetDateTime currentTime = null;
+        String expectedResult = "null";
+
+        String actualResult = offsetDateTimeMapper.writeValueAsString(currentTime);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void should_convert_a_String_to_OffsetDateTime() throws JsonProcessingException {
+        String currentTime = "\"2021-12-15T10:25:17.000123456+01:00\"";
+        OffsetDateTime expectedResult = OffsetDateTime.of(2021, 12, 15, 10, 25, 17, 123456, ZoneOffset.of("+01:00"));
+
+        OffsetDateTime actualResult = offsetDateTimeMapper.readValue(currentTime, OffsetDateTime.class);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+
+    @Test
+    public void should_convert_a_null_String_to_a_null_OffsetDateTime() throws JsonProcessingException {
+        String currentTime = "null";
+
+        OffsetDateTime actualResult = offsetDateTimeMapper.readValue(currentTime, OffsetDateTime.class);
+
+        assertNull(actualResult);
+    }
+
+}


### PR DESCRIPTION
custom ObjectMapperSupplier to serialize and deserialize an OffsetDateTime without loosing timezone

Hello @vladmihalcea ,

i'm not sure if I followed the complete code style. I also couldn't find an example project therefore I added the OffsetDateTimeObjectMapperSupplier to the codebase from hibernate-types-52 and hibernate-types-55

