### PR TITLE
remove extra 0 on ehcache dependency

### DIFF
--- a/hibernate-types-60/pom.xml
+++ b/hibernate-types-60/pom.xml
@@ -88,7 +88,7 @@
         <jackson-module-jaxb-annotation>2.12.6</jackson-module-jaxb-annotation>
         <guava.version>29.0-jre</guava.version>
 
-        <ehcache.version>3.10.0</ehcache.version>
+        <ehcache.version>3.1.0</ehcache.version>
 
     </properties>
 


### PR DESCRIPTION
Please review my change on POM.xml, I only change the version number of ehcache.

I tried to run the latest test a few minutes ago and maven keeps showing me errors.
It disturbing for a while but I found the version number was not match with Maven Repository, and it's good after I remove that.