### PR TITLE
ehcache 3.10.0 has dependencies that are not in maven central

### DIFF
--- a/hibernate-types-60/pom.xml
+++ b/hibernate-types-60/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.0-b180830.0359</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -81,14 +81,14 @@
         <jdk.version>11</jdk.version>
 
         <hibernate.version>6.0.0.Final</hibernate.version>
-        <postgresql.version>42.3.3</postgresql.version>
+        <postgresql.version>42.3.4</postgresql.version>
 
         <mysql.version>8.0.28</mysql.version>
-        <jackson-databind.version>2.12.6.1</jackson-databind.version>
-        <jackson-module-jaxb-annotation>2.12.6</jackson-module-jaxb-annotation>
-        <guava.version>29.0-jre</guava.version>
+        <jackson-databind.version>2.13.2.2</jackson-databind.version>
+        <jackson-module-jaxb-annotation>2.13.2</jackson-module-jaxb-annotation>
+        <guava.version>31.1-jre</guava.version>
 
-        <ehcache.version>3.10.0</ehcache.version>
+        <ehcache.version>3.9.9</ehcache.version>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,11 @@
 
     <modules>
         <module>hibernate-types-60</module>
-        <module>hibernate-types-55</module>
+        <!--module>hibernate-types-55</module>
         <module>hibernate-types-52</module>
         <module>hibernate-types-5</module>
         <module>hibernate-types-43</module>
-        <module>hibernate-types-4</module>
+        <module>hibernate-types-4</module-->
     </modules>
 
     <dependencies>
@@ -327,7 +327,7 @@
     </distributionManagement>
 
     <properties>
-        <jdk.version>6</jdk.version>
+        <jdk.version>11</jdk.version>
         <jdk8>${env.JAVA_HOME_8}</jdk8>
 
         <console.log.level>DEBUG</console.log.level>
@@ -349,7 +349,7 @@
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
 
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.3</logback.version>
 
         <junit.version>4.8.1</junit.version>


### PR DESCRIPTION
Wanted to upgrade a project to jakarta and hibernate 6, had an issue with using hibernate-types-60, causing a build error because of dependencies in ehcache 3.10 (see below).

Things started to work when downgrading ehcache: <ehcache.version>3.9.9</ehcache.version>
I'm not really a java guy, so there might be something else I'm missing.

This pull request just builds hibernate-types-60 as I had no intention to install java 6 to make things work.

Note: jaxb-api.jar:2.3.0-b161121.1438 is not in maven central


This it the error I experienced.
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project hibernate-types-60: Could not resolve dependencies for project com.vladmihalcea:hibernate-types-60:jar:2.16.2-SNAPSHOT: Failed to collect dependencies at org.ehcache:ehcache:jar:3.10.0 -> org.glassfish.jaxb:jaxb-runtime:jar:2.3.0-b170127.1453 -> org.glassfish.jaxb:jaxb-core:jar:2.3.0-b170127.1453 -> javax.xml.bind:jaxb-api:jar:2.3.0-b161121.1438: Failed to read artifact descriptor for javax.xml.bind:jaxb-api:jar:2.3.0-b161121.1438: Could not transfer artifact javax.xml.bind:jaxb-api:pom:2.3.0-b161121.1438 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [releases.java.net (http://maven.java.net/content/repositories/releases/, default, releases+snapshots), shapshots.java.net (http://maven.java.net/content/repositories/snapshots/, default, releases+snapshots), jvnet-nexus-staging (http://maven.java.net/content/repositories/staging/, default, releases+snapshots), netbeans (http://bits.netbeans.org/nexus/content/groups/netbeans, default, releases)] -> [Help 1]


