### PR TITLE
Fix build error due to decomissioned repo for hibernate-types-60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,13 @@
         <connection>scm:git:git@github.com:vladmihalcea/hibernate-types.git</connection>
         <tag>HEAD</tag>
     </scm>
-
+    <repositories>
+        <repository>
+            <id>netbeans</id>
+            <name>NetBeans</name>
+            <url>http://netbeans.apidesign.org/maven2/</url>
+        </repository>
+    </repositories>
     <modules>
         <module>hibernate-types-60</module>
         <module>hibernate-types-55</module>


### PR DESCRIPTION
When I execute the command `mvn clean compile` in root of the project, I get the following error in hibernate-types-60: 
`Could not find artifact javax.xml.bind:jaxb-api:pom:2.3.0-b161121.1438 in central (https://repo.maven.apache.org/maven2)`
Caused by decommissioned repo
https://bits.netbeans.org/nexus/content/groups/netbeans/javax/xml/bind/jaxb-api/2.3.0-b161121.1438/jaxb-api-2.3.0-b161121.1438.pom
and this is a solution https://netbeans.apache.org/about/oracle-transition.html:
To add fallback repository for this dependency