### PR TITLE
Update Guava version to version 31.1

### DIFF
--- a/hibernate-types-52/pom.xml
+++ b/hibernate-types-52/pom.xml
@@ -73,7 +73,7 @@
         <mysql.version>8.0.28</mysql.version>
         <jackson-databind.version>2.12.6.1</jackson-databind.version>
         <jackson-module-jaxb-annotation>2.12.6</jackson-module-jaxb-annotation>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
 
     </properties>
 

--- a/hibernate-types-55/pom.xml
+++ b/hibernate-types-55/pom.xml
@@ -72,7 +72,7 @@
         <mysql.version>8.0.28</mysql.version>
         <jackson-databind.version>2.12.6.1</jackson-databind.version>
         <jackson-module-jaxb-annotation>2.12.6</jackson-module-jaxb-annotation>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
 
     </properties>
 

--- a/hibernate-types-60/pom.xml
+++ b/hibernate-types-60/pom.xml
@@ -87,7 +87,7 @@
         <mysql.version>8.0.28</mysql.version>
         <jackson-databind.version>2.12.6.1</jackson-databind.version>
         <jackson-module-jaxb-annotation>2.12.6</jackson-module-jaxb-annotation>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
 
         <ehcache.version>3.10.0</ehcache.version>
 


### PR DESCRIPTION
Guava should be updated to 31.1 because of a recent vulnerability in 29.0. 

Compiles and works just fine with 31.1.