### PR TITLE
Fix Envers compatibility with ImmutableType

### DIFF
--- a/hibernate-types-55/pom.xml
+++ b/hibernate-types-55/pom.xml
@@ -25,6 +25,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers</artifactId>
+            <version>${hibernate.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind.version}</version>

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/HibernateTypesContributor.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/HibernateTypesContributor.java
@@ -101,13 +101,13 @@ public class HibernateTypesContributor implements TypeContributor {
         return this;
     }
 
+    private HibernateTypesContributor contributeType(TypeContributions typeContributions, ImmutableType<?> type) {
+        typeContributions.contributeType(type);
+        return this;
+    }
+
     private HibernateTypesContributor contributeType(TypeContributions typeContributions, UserType type) {
-        if(type instanceof ImmutableType) {
-            ImmutableType immutableType = (ImmutableType) type;
-            typeContributions.contributeType(immutableType, immutableType.getName());
-        } else {
-            typeContributions.contributeType(type, type.getClass().getSimpleName());
-        }
+        typeContributions.contributeType(type, type.getClass().getSimpleName());
         return this;
     }
 }

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/ImmutableType.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/ImmutableType.java
@@ -8,10 +8,10 @@ import org.hibernate.engine.spi.Mapping;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.collections.ArrayHelper;
+import org.hibernate.type.BasicType;
 import org.hibernate.type.ForeignKeyDirection;
 import org.hibernate.type.Type;
 import org.hibernate.type.descriptor.java.IncomparableComparator;
-import org.hibernate.type.spi.TypeBootstrapContext;
 import org.hibernate.usertype.UserType;
 
 import java.io.Serializable;
@@ -29,7 +29,7 @@ import java.util.Map;
  *
  * @author Vlad Mihalcea
  */
-public abstract class ImmutableType<T> implements UserType, Type {
+public abstract class ImmutableType<T> implements UserType, BasicType {
 
     private final Configuration configuration;
 
@@ -319,5 +319,10 @@ public abstract class ImmutableType<T> implements UserType, Type {
     @Override
     public boolean[] toColumnNullness(Object value, Mapping mapping) {
         return value == null ? ArrayHelper.FALSE : ArrayHelper.TRUE;
+    }
+
+    @Override
+    public String[] getRegistrationKeys() {
+        return new String[]{getName()};
     }
 }

--- a/hibernate-types-55/src/test/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreTypeTest.java
+++ b/hibernate-types-55/src/test/java/com/vladmihalcea/hibernate/type/basic/PostgreSQLHStoreTypeTest.java
@@ -5,6 +5,7 @@ import org.hibernate.Session;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+import org.hibernate.envers.Audited;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -67,6 +68,7 @@ public class PostgreSQLHStoreTypeTest extends AbstractPostgreSQLIntegrationTest 
         });
     }
 
+    @Audited
     @Entity(name = "Book")
     @Table(name = "book")
     @TypeDef(name = "hstore", typeClass = PostgreSQLHStoreType.class)


### PR DESCRIPTION
Envers expects (simple) audited types to implement the `BasicType` interface. This commit changes The `ImmutableType` to implement `BasicType` rather than `Type`.

The first commit is work in progress: It only applies the change to  `hibernate-types-55` as a template. If the change is OK, it will be applied to other `hibernate-types-*` as well.

Resolves: #463