### PR TITLE
Enhancement: Add wildcard on Range class

### DIFF
--- a/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
+++ b/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/range/Range.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
  * @author Edgar Asatryan
  * @author Vlad Mihalcea
  */
-public final class Range<T extends Comparable> implements Serializable {
+public final class Range<T extends Comparable<? super T>> implements Serializable {
 
     public static final int LOWER_INCLUSIVE = 1 << 1;
     public static final int LOWER_EXCLUSIVE = 1 << 2;
@@ -88,7 +88,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The closed range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> closed(T lower, T upper) {
+    public static <T extends Comparable<? super T>> Range<T> closed(T lower, T upper) {
         Objects.requireNonNull(lower);
         Objects.requireNonNull(upper);
         return new Range<>(lower, upper, LOWER_INCLUSIVE | UPPER_INCLUSIVE, (Class<T>) lower.getClass());
@@ -109,7 +109,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> open(T lower, T upper) {
+    public static <T extends Comparable<? super T>> Range<T> open(T lower, T upper) {
         Objects.requireNonNull(lower);
         Objects.requireNonNull(upper);
         return new Range<>(lower, upper, LOWER_EXCLUSIVE | UPPER_EXCLUSIVE, (Class<T>) lower.getClass());
@@ -130,7 +130,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> openClosed(T lower, T upper) {
+    public static <T extends Comparable<? super T>> Range<T> openClosed(T lower, T upper) {
         Objects.requireNonNull(lower);
         Objects.requireNonNull(upper);
         return new Range<>(lower, upper, LOWER_EXCLUSIVE | UPPER_INCLUSIVE, (Class<T>) lower.getClass());
@@ -151,7 +151,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> closedOpen(T lower, T upper) {
+    public static <T extends Comparable<? super T>> Range<T> closedOpen(T lower, T upper) {
         Objects.requireNonNull(lower);
         Objects.requireNonNull(upper);
         return new Range<>(lower, upper, LOWER_INCLUSIVE | UPPER_EXCLUSIVE, (Class<T>) lower.getClass());
@@ -171,7 +171,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> openInfinite(T lower) {
+    public static <T extends Comparable<? super T>> Range<T> openInfinite(T lower) {
         Objects.requireNonNull(lower);
         return new Range<>(lower, null, LOWER_EXCLUSIVE | UPPER_INFINITE, (Class<T>) lower.getClass());
     }
@@ -190,9 +190,9 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> closedInfinite(T lower) {
+    public static <T extends Comparable<? super T>> Range<T> closedInfinite(T lower) {
         Objects.requireNonNull(lower);
-        return new Range(lower, null, LOWER_INCLUSIVE | UPPER_INFINITE, lower.getClass());
+        return new Range<>(lower, null, LOWER_INCLUSIVE | UPPER_INFINITE, (Class<T>) lower.getClass());
     }
 
     /**
@@ -209,7 +209,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> infiniteOpen(T upper) {
+    public static <T extends Comparable<? super T>> Range<T> infiniteOpen(T upper) {
         Objects.requireNonNull(upper);
         return new Range<>(null, upper, UPPER_EXCLUSIVE | LOWER_INFINITE, (Class<T>) upper.getClass());
     }
@@ -228,7 +228,7 @@ public final class Range<T extends Comparable> implements Serializable {
      * @return The range.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> infiniteClosed(T upper) {
+    public static <T extends Comparable<? super T>> Range<T> infiniteClosed(T upper) {
         Objects.requireNonNull(upper);
         return new Range<>(null, upper, UPPER_INCLUSIVE | LOWER_INFINITE, (Class<T>) upper.getClass());
     }
@@ -246,13 +246,11 @@ public final class Range<T extends Comparable> implements Serializable {
      *
      * @return The infinite range.
      */
-    @SuppressWarnings("unchecked")
-    public static <T extends Comparable<?>> Range<T> infinite(Class<T> cls) {
+    public static <T extends Comparable<? super T>> Range<T> infinite(Class<T> cls) {
         return new Range<>(null, null, LOWER_INFINITE | UPPER_INFINITE, cls);
     }
 
-    @SuppressWarnings("unchecked")
-    public static <T extends Comparable> Range<T> ofString(String str, Function<String, T> converter, Class<T> clazz) {
+    public static <T extends Comparable<? super T>> Range<T> ofString(String str, Function<String, T> converter, Class<T> clazz) {
         if(str.equals(EMPTY)) {
             return emptyRange(clazz);
         }
@@ -562,7 +560,6 @@ public final class Range<T extends Comparable> implements Serializable {
      *
      * @return Whether {@code point} in this range or not.
      */
-    @SuppressWarnings("unchecked")
     public boolean contains(T point) {
         boolean l = hasLowerBound();
         boolean u = hasUpperBound();
@@ -628,8 +625,8 @@ public final class Range<T extends Comparable> implements Serializable {
         return clazz;
     }
 
-    public static <R extends Comparable<R>> Range<R> emptyRange(Class<R> clazz) {
-        return new Range<R>(
+    public static <R extends Comparable<? super R>> Range<R> emptyRange(Class<R> clazz) {
+        return new Range<>(
             null,
             null,
             LOWER_INFINITE|UPPER_INFINITE,


### PR DESCRIPTION
Work on #478:
Add wildcard in class declaration and static factory methods for Range class. Remove superfluous suppression of unchecked warnings on static factory methods where applicable.
