### PR TITLE
To make hibernate-types work with GraalVM, we need to minimize reflec…

### DIFF
--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -66,7 +66,7 @@ public class JsonTypeDescriptor
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         Type type = (xProperty instanceof JavaXMember) ?
-            ReflectionUtils.invokeGetter(xProperty, "javaType") :
+            ((JavaXMember) xProperty).getJavaType() :
             ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         setPropertyClass(type);
     }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
@@ -128,7 +128,7 @@ public class PostgreSQLRangeType extends ImmutableType<Range> implements Dynamic
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
@@ -515,7 +515,7 @@ public class PostgreSQLGuavaRangeType extends ImmutableType<Range> implements Dy
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
@@ -24,7 +24,7 @@ public class PostgreSQLTSVectorTypeDescriptor extends AbstractTypeDescriptor<Obj
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonTypeDescriptor.java
@@ -66,7 +66,7 @@ public class JsonTypeDescriptor
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         Type type = (xProperty instanceof JavaXMember) ?
-            ReflectionUtils.invokeGetter(xProperty, "javaType") :
+            ((JavaXMember) xProperty).getJavaType() :
             ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         setPropertyClass(type);
     }

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
@@ -133,7 +133,7 @@ public class PostgreSQLRangeType extends ImmutableType<Range> implements Dynamic
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
@@ -515,7 +515,7 @@ public class PostgreSQLGuavaRangeType extends ImmutableType<Range> implements Dy
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
@@ -24,7 +24,7 @@ public class PostgreSQLTSVectorTypeDescriptor extends AbstractTypeDescriptor<Obj
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
+++ b/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/json/internal/JsonJavaTypeDescriptor.java
@@ -73,7 +73,7 @@ public class JsonJavaTypeDescriptor extends AbstractClassJavaType<Object> implem
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         Type type = (xProperty instanceof JavaXMember) ?
-            ReflectionUtils.invokeGetter(xProperty, "javaType") :
+            ((JavaXMember) xProperty).getJavaType() :
             ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         setPropertyClass(type);
     }

--- a/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
+++ b/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/range/PostgreSQLRangeType.java
@@ -133,7 +133,7 @@ public class PostgreSQLRangeType extends ImmutableType<Range> implements Dynamic
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
+++ b/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/range/guava/PostgreSQLGuavaRangeType.java
@@ -515,7 +515,7 @@ public class PostgreSQLGuavaRangeType extends ImmutableType<Range> implements Dy
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }

--- a/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
+++ b/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/search/internal/PostgreSQLTSVectorTypeDescriptor.java
@@ -24,7 +24,7 @@ public class PostgreSQLTSVectorTypeDescriptor extends AbstractClassJavaType<Obje
     public void setParameterValues(Properties parameters) {
         final XProperty xProperty = (XProperty) parameters.get(DynamicParameterizedType.XPROPERTY);
         if (xProperty instanceof JavaXMember) {
-            type = ReflectionUtils.invokeGetter(xProperty, "javaType");
+            type = ((JavaXMember) xProperty).getJavaType();
         } else {
             type = ((ParameterType) parameters.get(PARAMETER_TYPE)).getReturnedClass();
         }


### PR DESCRIPTION
…tion usage. `getJavaType()` is available with a public getter, so we don't need reflection here.

I didn't change `types-43` and `types-5` because those versions still have a `protected` getter and need reflection, or we'd need to open the getter.

Fixes #343 