### PR TITLE
Do not need to clone strings with the generic serializer cloner

### DIFF
--- a/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hibernate-types-4/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -46,7 +46,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
                 }
             }
         }
-
+        if (object instanceof String) {
+            // String is immutable, no need to clone it.
+            return object;
+        }
         if (object instanceof Serializable) {
             try {
                 return (T) SerializationHelper.clone((Serializable) object);

--- a/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hibernate-types-43/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -46,7 +46,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
                 }
             }
         }
-
+        if (object instanceof String) {
+            // String is immutable, no need to clone it.
+            return object;
+        }
         if (object instanceof Serializable) {
             try {
                 return (T) SerializationHelper.clone((Serializable) object);

--- a/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hibernate-types-5/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -46,7 +46,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
                 }
             }
         }
-
+        if (object instanceof String) {
+            // String is immutable, no need to clone it.
+            return object;
+        }
         if (object instanceof Serializable) {
             try {
                 return (T) SerializationHelper.clone((Serializable) object);

--- a/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hibernate-types-52/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -46,6 +46,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
             }
         }
         }
+        if (object instanceof String) {
+            // String is immutable, no need to clone it.
+            return object;
+        }
         if (object instanceof Serializable) {
             try {
                 return (T) SerializationHelper.clone((Serializable) object);

--- a/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hibernate-types-55/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -46,6 +46,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
                 }
             }
         }
+        if (object instanceof String) {
+            // String is immutable, no need to clone it.
+            return object;
+        }
         if (object instanceof Serializable) {
             try {
                 return (T) SerializationHelper.clone((Serializable) object);

--- a/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hibernate-types-60/src/main/java/com/vladmihalcea/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -46,6 +46,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
                 }
             }
         }
+        if (object instanceof String) {
+            // String is immutable, no need to clone it.
+            return object;
+        }
         if (object instanceof Serializable) {
             try {
                 return (T) SerializationHelper.clone((Serializable) object);


### PR DESCRIPTION
as they are immutable.

Profiling my application, I've noticed, that a lot's of time spent in the cloning of strings with SerializationHelper.clone(...) - it took 5%-6% on average, which seemed unnecessary.
 In my entity, the JSON column mapped to a single String field, because the app doesn't need to deal with the actual content of json, just gets the value from PostgreSQL and sends back to the client.
With this change, this cloning doesn't happen anymore.