### PR TITLE
Add support for addScalar in the Hibernate 7 module

### DIFF
--- a/hypersistence-utils-hibernate-70/pom.xml
+++ b/hypersistence-utils-hibernate-70/pom.xml
@@ -204,7 +204,7 @@
     </build>
 
     <properties>
-        <jdk.version>11</jdk.version>
+        <jdk.version>17</jdk.version>
         <jdk-test.version>17</jdk-test.version>
         <maven.compiler.release>${jdk.version}</maven.compiler.release>
         <maven.compiler.testRelease>${jdk-test.version}</maven.compiler.testRelease>

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/basic/internal/NumberJdbcTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/basic/internal/NumberJdbcTypeDescriptor.java
@@ -89,18 +89,20 @@ public class NumberJdbcTypeDescriptor implements JdbcType, ParameterizedType {
     }
 
     private JdbcType resolveJdbcTypeDescriptor() {
+    	  if(properties!=null && !properties.isEmpty()) {
         DynamicParameterizedType.ParameterType parameterType = ParameterTypeUtils.resolve(properties);
-        if (parameterType != null) {
-            String columnType = ParameterTypeUtils.getColumnType(parameterType);
-            if (!StringUtils.isBlank(columnType)) {
-                switch (columnType) {
-                    case "tinyint":
-                        return TinyIntJdbcType.INSTANCE;
-                    case "smallint":
-                        return SmallIntJdbcType.INSTANCE;
-                }
-            }
-        }
+	        if (parameterType != null) {
+	            String columnType = ParameterTypeUtils.getColumnType(parameterType);
+	            if (!StringUtils.isBlank(columnType)) {
+	                switch (columnType) {
+	                    case "tinyint":
+	                        return TinyIntJdbcType.INSTANCE;
+	                    case "smallint":
+	                        return SmallIntJdbcType.INSTANCE;
+	                }
+	            }
+	        }
+    	  }
         return IntegerJdbcType.INSTANCE;
     }
 

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonBlobType.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonBlobType.java
@@ -1,14 +1,15 @@
 package io.hypersistence.utils.hibernate.type.json;
 
+import java.lang.reflect.Type;
+import java.sql.Blob;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.hypersistence.utils.hibernate.type.MutableDynamicParameterizedType;
+
+import io.hypersistence.utils.hibernate.type.json.internal.AbstractJsonType;
 import io.hypersistence.utils.hibernate.type.json.internal.JsonBlobJdbcTypeDescriptor;
 import io.hypersistence.utils.hibernate.type.json.internal.JsonJavaTypeDescriptor;
 import io.hypersistence.utils.hibernate.type.util.JsonConfiguration;
 import io.hypersistence.utils.hibernate.type.util.ObjectMapperWrapper;
-
-import java.lang.reflect.Type;
-import java.sql.Blob;
 
 /**
  * <p>
@@ -26,7 +27,7 @@ import java.sql.Blob;
  *
  * @author Vlad Mihalcea
  */
-public class JsonBlobType extends MutableDynamicParameterizedType<Object, JsonBlobJdbcTypeDescriptor, JsonJavaTypeDescriptor> {
+public class JsonBlobType extends AbstractJsonType<Object> {
 
     public static final JsonBlobType INSTANCE = new JsonBlobType();
 

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonClobType.java
@@ -2,6 +2,7 @@ package io.hypersistence.utils.hibernate.type.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hypersistence.utils.hibernate.type.MutableDynamicParameterizedType;
+import io.hypersistence.utils.hibernate.type.json.internal.AbstractJsonType;
 import io.hypersistence.utils.hibernate.type.json.internal.JsonClobJdbcTypeDescriptor;
 import io.hypersistence.utils.hibernate.type.json.internal.JsonJavaTypeDescriptor;
 import io.hypersistence.utils.hibernate.type.util.JsonConfiguration;
@@ -9,6 +10,8 @@ import io.hypersistence.utils.hibernate.type.util.ObjectMapperWrapper;
 
 import java.lang.reflect.Type;
 import java.sql.Clob;
+
+import org.hibernate.boot.models.annotations.internal.ExtendsXmlAnnotation;
 
 /**
  * <p>
@@ -27,7 +30,7 @@ import java.sql.Clob;
  * @author Vlad Mihalcea
  * @author Andreas Gebhardt
  */
-public class JsonClobType extends MutableDynamicParameterizedType<Object, JsonClobJdbcTypeDescriptor, JsonJavaTypeDescriptor> {
+public class JsonClobType extends AbstractJsonType<Object> {
 
     public static final JsonClobType INSTANCE = new JsonClobType();
 

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonStringType.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonStringType.java
@@ -1,15 +1,17 @@
 package io.hypersistence.utils.hibernate.type.json;
 
+import java.lang.reflect.Type;
+
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.type.spi.TypeConfiguration;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.hypersistence.utils.hibernate.type.MutableDynamicParameterizedType;
+
+import io.hypersistence.utils.hibernate.type.json.internal.AbstractJsonType;
 import io.hypersistence.utils.hibernate.type.json.internal.JsonJavaTypeDescriptor;
 import io.hypersistence.utils.hibernate.type.json.internal.JsonStringJdbcTypeDescriptor;
 import io.hypersistence.utils.hibernate.type.util.JsonConfiguration;
 import io.hypersistence.utils.hibernate.type.util.ObjectMapperWrapper;
-import org.hibernate.type.descriptor.jdbc.JdbcType;
-import org.hibernate.type.spi.TypeConfiguration;
-
-import java.lang.reflect.Type;
 
 /**
  * <p>
@@ -34,7 +36,7 @@ import java.lang.reflect.Type;
  *
  * @author Vlad Mihalcea
  */
-public class JsonStringType extends MutableDynamicParameterizedType<Object, JsonStringJdbcTypeDescriptor, JsonJavaTypeDescriptor> {
+public class JsonStringType extends AbstractJsonType<Object> {
 
     public static final JsonStringType INSTANCE = new JsonStringType();
 

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/AbstractJsonType.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/internal/AbstractJsonType.java
@@ -1,0 +1,49 @@
+package io.hypersistence.utils.hibernate.type.json.internal;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hibernate.type.descriptor.converter.spi.BasicValueConverter;
+import org.hibernate.type.descriptor.java.AbstractClassJavaType;
+import org.hibernate.type.descriptor.java.JavaType;
+
+import io.hypersistence.utils.hibernate.type.MutableDynamicParameterizedType;
+import io.hypersistence.utils.hibernate.type.util.Configuration;
+
+public abstract class AbstractJsonType<T> extends MutableDynamicParameterizedType<T, AbstractJsonJdbcTypeDescriptor, AbstractClassJavaType<T>> {
+	@SuppressWarnings("unchecked")
+  private final class BasicValueConverterImplementation implements BasicValueConverter<T, Object> {
+		@Override
+		public @Nullable T toDomainValue(@Nullable Object relationalForm) {
+			return (T)relationalForm;
+		}
+
+		@Override
+		public @Nullable Object toRelationalValue(@Nullable T domainForm) {
+			return domainForm;
+		}
+
+		@Override
+		public JavaType<T> getDomainJavaType() {
+			return getJavaTypeDescriptor();
+		}
+
+		@Override
+		public JavaType<Object> getRelationalJavaType() {
+			return (JavaType<Object>) getJavaTypeDescriptor();
+		}
+	}
+
+	protected AbstractJsonType(Class<T> returnedClass, AbstractJsonJdbcTypeDescriptor jdbcTypeDescriptor,
+  		AbstractClassJavaType<T> javaTypeDescriptor, Configuration configuration) {
+      super(returnedClass, jdbcTypeDescriptor, javaTypeDescriptor, configuration);
+  }
+
+  protected AbstractJsonType(Class<T> returnedClass, AbstractJsonJdbcTypeDescriptor jdbcTypeDescriptor,
+  		AbstractClassJavaType<T> javaTypeDescriptor) {
+      super(returnedClass, jdbcTypeDescriptor, javaTypeDescriptor);
+  }
+  
+	@Override
+  public BasicValueConverter<T, Object> getValueConverter(){
+      return new BasicValueConverterImplementation();
+  }
+}

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/id/AbstractBatchSequenceGeneratorTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/id/AbstractBatchSequenceGeneratorTest.java
@@ -1,7 +1,9 @@
 package io.hypersistence.utils.hibernate.id;
 
+import io.hypersistence.utils.hibernate.id.AbstractBatchSequenceGeneratorTest.Post;
 import io.hypersistence.utils.hibernate.util.AbstractTest;
 import io.hypersistence.utils.test.providers.DataSourceProvider;
+import io.hypersistence.utils.test.transaction.EntityManagerTransactionConsumer;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -46,14 +48,18 @@ public abstract class AbstractBatchSequenceGeneratorTest extends AbstractTest {
     public void test() {
 
         QueryCountHolder.clear();
-        doInJPA(entityManager -> {
-            for (int i = 0; i < BATCH_SIZE; i++) {
-                Post post = new Post();
-
-                post.setTitle("Post " + i + 1);
-                entityManager.persist(post);
-            }
-        });
+        
+     		EntityManagerTransactionConsumer work = entityManager -> {
+    			for (int i = 0; i < BATCH_SIZE; i++) {
+            Post post = new Post();
+	
+	            post.setTitle("Post " + i + 1);
+	            entityManager.persist(post);
+	        }
+    		};
+        
+        
+        doInJPA(work);
 
         QueryCount queryCount = QueryCountHolder.getGrandTotal();
         assertEquals(1L, queryCount.getInsert());

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/array/BindArrayTypeQueryParameterTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/array/BindArrayTypeQueryParameterTest.java
@@ -84,14 +84,14 @@ public class BindArrayTypeQueryParameterTest extends AbstractPostgreSQLIntegrati
     @Test
     public void testJPQLWithExplicitParameterTypeBinding() {
         doInJPA(entityManager -> {
-            Event event = (Event) entityManager
+            Event event = (Event) ((Query)entityManager
             .createQuery(
                 "select e " +
                 "from Event e " +
                 "where " +
                 "   cast(fn_array_contains(e.values, :arrayValues) as Boolean) = true", Event.class)
             .unwrap(org.hibernate.query.Query.class)
-            .setParameter("arrayValues", new int[]{2, 3}, IntArrayType.INSTANCE)
+            .setParameter("arrayValues", new int[]{2, 3}, IntArrayType.INSTANCE))
             .getSingleResult();
 
             assertArrayEquals(new int[]{1, 2, 3}, event.getValues());
@@ -134,9 +134,9 @@ public class BindArrayTypeQueryParameterTest extends AbstractPostgreSQLIntegrati
                 )
             );
 
-            Event event = (Event) entityManager.createQuery(cq)
+            Event event = (Event)((Query) entityManager.createQuery(cq)
             .unwrap(Query.class)
-            .setParameter("arrayValues", new int[]{2, 3}, IntArrayType.INSTANCE)
+            .setParameter("arrayValues", new int[]{2, 3}, IntArrayType.INSTANCE))
             .getSingleResult();
 
             assertArrayEquals(new int[]{1, 2, 3}, event.getValues());

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeTest.java
@@ -73,13 +73,13 @@ public class PostgreSQLEnumArrayTypeTest extends AbstractPostgreSQLIntegrationTe
         });
 
         doInJPA(entityManager -> {
-            entityManager
+            ((Query)entityManager
             .createQuery(
                 "select ua " +
                 "from UserAccountEntity ua " +
                 "where ua.roles = :roles", UserAccount.class)
             .unwrap(Query.class)
-            .setParameter("roles", requiredRoles, new EnumArrayType(UserRole[].class, "user_role"))
+            .setParameter("roles", requiredRoles, new EnumArrayType(UserRole[].class, "user_role")))
             .getResultList();
         });
     }

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLCITextTypeTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLCITextTypeTest.java
@@ -114,11 +114,12 @@ public class PostgreSQLCITextTypeTest extends AbstractPostgreSQLIntegrationTest 
         doInJPA(new EntityManagerTransactionFunction<Void>() {
             @Override
             public Void apply(EntityManager entityManager) {
-                List<Country> countries = entityManager.createQuery("""
-                    SELECT c
-                    FROM Country AS c
-                    WHERE c.name LIKE :token
-                    """)
+            	
+            	 String query=" SELECT c "
+            	 		+ " FROM Country AS c "
+            	 		+ " WHERE c.name LIKE :token";
+            	
+                List<Country> countries = entityManager.createQuery(query, Country.class)
                     .setParameter("token", token)
                 .getResultList();
 

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonStringPropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/OracleJsonStringPropertyTest.java
@@ -12,7 +12,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -61,7 +60,6 @@ public class OracleJsonStringPropertyTest extends AbstractOracleIntegrationTest 
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(entityManager -> {
             Book book = entityManager.unwrap(Session.class)

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonNodeTypeTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonNodeTypeTest.java
@@ -1,6 +1,8 @@
 package io.hypersistence.utils.hibernate.type.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import io.hypersistence.utils.hibernate.type.json.PostgreSQLJsonNodeTypeTest.BookDTO;
 import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil;
 import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
 import io.hypersistence.utils.jdbc.validator.SQLStatementCountValidator;
@@ -137,11 +139,12 @@ public class PostgreSQLJsonNodeTypeTest extends AbstractPostgreSQLIntegrationTes
         assertEquals(book.getIsbn(), _book.getIsbn());
     }
 
+    @Ignore("TODO PROBLEM WITH setResultTransformer")
     @Test
-    @Ignore("TODO : addScalar")
     public void testNativeQueryResultTransformer() {
         doInJPA(entityManager -> {
-            List<BookDTO> books = entityManager.createNativeQuery(
+            @SuppressWarnings({ "unchecked", "deprecation" })
+						List<BookDTO> books = entityManager.createNativeQuery(
                 "SELECT " +
                 "       b.id as id, " +
                 "       b.properties as properties " +
@@ -150,7 +153,7 @@ public class PostgreSQLJsonNodeTypeTest extends AbstractPostgreSQLIntegrationTes
             .setParameter("id", 0)
             .unwrap(NativeQuery.class)
             .addScalar("properties", JsonNode.class)
-            .setResultTransformer(new AliasToBeanResultTransformer(BookDTO.class))
+            .setResultTransformer(new AliasToBeanResultTransformer<BookDTO>(BookDTO.class))
             .getResultList();
 
             assertEquals(1, books.size());

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonParameterizedPropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonParameterizedPropertyTest.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -60,7 +59,6 @@ public class PostgreSQLJsonParameterizedPropertyTest extends AbstractPostgreSQLI
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(entityManager -> {
             Book book = entityManager.unwrap(Session.class)

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonStringPropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/PostgreSQLJsonStringPropertyTest.java
@@ -10,7 +10,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -59,7 +58,6 @@ public class PostgreSQLJsonStringPropertyTest extends AbstractPostgreSQLIntegrat
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(entityManager -> {
             Book book = entityManager.unwrap(Session.class)

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/SQLServerJsonStringPropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/SQLServerJsonStringPropertyTest.java
@@ -12,7 +12,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -61,7 +60,6 @@ public class SQLServerJsonStringPropertyTest extends AbstractSQLServerIntegratio
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(entityManager -> {
             Book book = entityManager.unwrap(Session.class)

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypeBlobPropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypeBlobPropertyTest.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -42,7 +41,6 @@ public class GenericOracleJsonTypeBlobPropertyTest extends AbstractOracleIntegra
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(new EntityManagerTransactionFunction<Void>() {
             @Override

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypeClobPropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypeClobPropertyTest.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -42,7 +41,6 @@ public class GenericOracleJsonTypeClobPropertyTest extends AbstractOracleIntegra
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(new EntityManagerTransactionFunction<Void>() {
             @Override

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypePropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypePropertyTest.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -42,7 +41,6 @@ public class GenericOracleJsonTypePropertyTest extends AbstractOracleIntegration
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(new EntityManagerTransactionFunction<Void>() {
             @Override

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypeVarcharPropertyTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericOracleJsonTypeVarcharPropertyTest.java
@@ -12,7 +12,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -43,7 +42,6 @@ public class GenericOracleJsonTypeVarcharPropertyTest extends AbstractOracleInte
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(new EntityManagerTransactionFunction<Void>() {
             @Override

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericPostgreSQLJsonStringTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/json/generic/GenericPostgreSQLJsonStringTest.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Type;
 import org.hibernate.jpa.boot.spi.TypeContributorList;
 import org.hibernate.query.NativeQuery;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -60,7 +59,6 @@ public class GenericPostgreSQLJsonStringTest extends AbstractPostgreSQLIntegrati
     }
 
     @Test
-    @Ignore("TODO : addScalar")
     public void test() {
         doInJPA(entityManager -> {
             Book book = entityManager.unwrap(Session.class)


### PR DESCRIPTION
Hi @vladmihalcea , I found a way to solve the issues with addScalar during the migration to Hibernate 7. I'm submitting the pull request for your review. It seemed like the best approach to me — let me know what you think. There's only one test still failing, annotated with @Ignore("TODO PROBLEM WITH setResultTransformer"). The issue seems similar, but in Hibernate 7 it doesn't pass where we expect it to.

For h7 i have upgraded java to 17 according with https://hibernate.org/orm/releases/7.0/

There are also a few minor changes in the test cases that I made just to be able to run them from the IDE without errors — feel free to ignore those if not relevant.