### PR TITLE
Improve the non-serializable error message in the ObjectMapperJsonSerializer to indicate the culprit Java class

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -22,7 +22,7 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         try {
             return (T) SerializationHelper.clone((Serializable) object);
         } catch (SerializationException e) {
-            throw new IllegalArgumentException("The JPA specification requires that the entity attributes are Serializable. The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation. If you want to use JSON object cloning, then you can provide your own custom JsonSerializer. Offending object : " + object, e);
+            throw new IllegalArgumentException("The JPA specification requires that the entity attributes are Serializable. The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation. If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.", e);
         }
     }
 }

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -22,12 +22,7 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         try {
             return (T) SerializationHelper.clone((Serializable) object);
         } catch (SerializationException e) {
-            String message = """
-                The JPA specification requires that the entity attributes are Serializable.\
-                The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation.\
-                If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.\
-                Offending object : %s""".formatted(object);
-            throw new IllegalArgumentException(message, e);
+            throw new IllegalArgumentException("The JPA specification requires that the entity attributes are Serializable. The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation. If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.", e);
         }
     }
 }

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -22,12 +22,7 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         try {
             return (T) SerializationHelper.clone((Serializable) object);
         } catch (SerializationException e) {
-            String message = """
-                The JPA specification requires that the entity attributes are Serializable.\
-                The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation.\
-                If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.\
-                Offending object : %s""".formatted(object);
-            throw new IllegalArgumentException(message, e);
+            throw new IllegalArgumentException("The JPA specification requires that the entity attributes are Serializable. The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation. If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.", e);
         }
     }
 }

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -22,12 +22,7 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         try {
             return (T) SerializationHelper.clone((Serializable) object);
         } catch (SerializationException e) {
-            String message = """
-                The JPA specification requires that the entity attributes are Serializable.\
-                The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation.\
-                If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.\
-                Offending object : %s""".formatted(object);
-            throw new IllegalArgumentException(message, e);
+            throw new IllegalArgumentException("The JPA specification requires that the entity attributes are Serializable. The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation. If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.", e);
         }
     }
 }


### PR DESCRIPTION
Related to #831 

If the text block refactor is not relevant, tell me and I'll drop it.
Looked more readable to me.