### PR TITLE
EnumArrayType: Persist enums by name() rather than by toString() as on read enum's valueOf() is used, which looks up Enums by name

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,5 +1,7 @@
 package io.hypersistence.utils.hibernate.type.array.internal;
 
+import org.hibernate.type.descriptor.WrapperOptions;
+
 import java.util.Properties;
 
 /**
@@ -28,5 +30,18 @@ public class EnumArrayTypeDescriptor
     public void setParameterValues(Properties parameters) {
         sqlArrayType = parameters.getProperty(AbstractArrayType.SQL_ARRAY_TYPE);
         super.setParameterValues(parameters);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public <X> X unwrap(Enum[] value, Class<X> type, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        String[] names = new String[value.length];
+        for (int i = 0; i < value.length; i++) {
+            names[i] = value[i] == null ? null : value[i].name();
+        }
+        return (X) names;
     }
 }

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
@@ -1,0 +1,110 @@
+package io.hypersistence.utils.hibernate.type.array;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests that EnumArrayType correctly persists enums by their name()
+ * even when toString() returns a different value.
+ */
+public class PostgreSQLEnumArrayTypeNameTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                UserAccount.class
+        };
+    }
+
+    @Override
+    protected void beforeInit() {
+        executeStatement("DROP TYPE IF EXISTS user_role_name;");
+        executeStatement("CREATE TYPE user_role_name AS ENUM ('ROLE_ADMIN', 'ROLE_USER');");
+    }
+
+    @Test
+    public void testRoundTripWithCustomToString() {
+        UserRole[] userRoles = {UserRole.ROLE_ADMIN, UserRole.ROLE_USER};
+
+        doInJPA(entityManager -> {
+            UserAccount account = new UserAccount();
+            account.setUsername("vladmihalcea.com");
+            account.setRoles(userRoles);
+            entityManager.persist(account);
+        });
+
+        doInJPA(entityManager -> {
+            UserAccount singleResult = entityManager
+                .createQuery(
+                    "select ua " +
+                    "from UserAccountNameTest ua " +
+                    "where ua.username = :username", UserAccount.class)
+                .setParameter("username", "vladmihalcea.com")
+                .getSingleResult();
+
+            assertArrayEquals(userRoles, singleResult.getRoles());
+        });
+    }
+
+    public enum UserRole {
+        ROLE_ADMIN,
+        ROLE_USER;
+
+        @Override
+        public String toString() {
+            return name().replace("ROLE_", "");
+        }
+    }
+
+    @Entity(name = "UserAccountNameTest")
+    @Table(name = "users_name_test")
+    public static class UserAccount {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String username;
+
+        @Type(
+            value = EnumArrayType.class,
+            parameters = @org.hibernate.annotations.Parameter(
+                name = "sql_array_type",
+                value = "user_role_name"
+            )
+        )
+        @Column(
+            name = "roles",
+            columnDefinition = "user_role_name[]"
+        )
+        private UserRole roles[];
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public UserRole[] getRoles() {
+            return roles;
+        }
+
+        public void setRoles(UserRole[] roles) {
+            this.roles = roles;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,5 +1,7 @@
 package io.hypersistence.utils.hibernate.type.array.internal;
 
+import org.hibernate.type.descriptor.WrapperOptions;
+
 import java.util.Properties;
 
 /**
@@ -28,5 +30,18 @@ public class EnumArrayTypeDescriptor
     public void setParameterValues(Properties parameters) {
         sqlArrayType = parameters.getProperty(AbstractArrayType.SQL_ARRAY_TYPE);
         super.setParameterValues(parameters);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public <X> X unwrap(Enum[] value, Class<X> type, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        String[] names = new String[value.length];
+        for (int i = 0; i < value.length; i++) {
+            names[i] = value[i] == null ? null : value[i].name();
+        }
+        return (X) names;
     }
 }

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
@@ -1,0 +1,110 @@
+package io.hypersistence.utils.hibernate.type.array;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests that EnumArrayType correctly persists enums by their name()
+ * even when toString() returns a different value.
+ */
+public class PostgreSQLEnumArrayTypeNameTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                UserAccount.class
+        };
+    }
+
+    @Override
+    protected void beforeInit() {
+        executeStatement("DROP TYPE IF EXISTS user_role_name;");
+        executeStatement("CREATE TYPE user_role_name AS ENUM ('ROLE_ADMIN', 'ROLE_USER');");
+    }
+
+    @Test
+    public void testRoundTripWithCustomToString() {
+        UserRole[] userRoles = {UserRole.ROLE_ADMIN, UserRole.ROLE_USER};
+
+        doInJPA(entityManager -> {
+            UserAccount account = new UserAccount();
+            account.setUsername("vladmihalcea.com");
+            account.setRoles(userRoles);
+            entityManager.persist(account);
+        });
+
+        doInJPA(entityManager -> {
+            UserAccount singleResult = entityManager
+                .createQuery(
+                    "select ua " +
+                    "from UserAccountNameTest ua " +
+                    "where ua.username = :username", UserAccount.class)
+                .setParameter("username", "vladmihalcea.com")
+                .getSingleResult();
+
+            assertArrayEquals(userRoles, singleResult.getRoles());
+        });
+    }
+
+    public enum UserRole {
+        ROLE_ADMIN,
+        ROLE_USER;
+
+        @Override
+        public String toString() {
+            return name().replace("ROLE_", "");
+        }
+    }
+
+    @Entity(name = "UserAccountNameTest")
+    @Table(name = "users_name_test")
+    public static class UserAccount {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String username;
+
+        @Type(
+            value = EnumArrayType.class,
+            parameters = @org.hibernate.annotations.Parameter(
+                name = "sql_array_type",
+                value = "user_role_name"
+            )
+        )
+        @Column(
+            name = "roles",
+            columnDefinition = "user_role_name[]"
+        )
+        private UserRole roles[];
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public UserRole[] getRoles() {
+            return roles;
+        }
+
+        public void setRoles(UserRole[] roles) {
+            this.roles = roles;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,5 +1,7 @@
 package io.hypersistence.utils.hibernate.type.array.internal;
 
+import org.hibernate.type.descriptor.WrapperOptions;
+
 import java.util.Properties;
 
 /**
@@ -28,5 +30,18 @@ public class EnumArrayTypeDescriptor
     public void setParameterValues(Properties parameters) {
         sqlArrayType = parameters.getProperty(AbstractArrayType.SQL_ARRAY_TYPE);
         super.setParameterValues(parameters);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public <X> X unwrap(Enum[] value, Class<X> type, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        String[] names = new String[value.length];
+        for (int i = 0; i < value.length; i++) {
+            names[i] = value[i] == null ? null : value[i].name();
+        }
+        return (X) names;
     }
 }

--- a/hypersistence-utils-hibernate-71/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
+++ b/hypersistence-utils-hibernate-71/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
@@ -1,0 +1,110 @@
+package io.hypersistence.utils.hibernate.type.array;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests that EnumArrayType correctly persists enums by their name()
+ * even when toString() returns a different value.
+ */
+public class PostgreSQLEnumArrayTypeNameTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                UserAccount.class
+        };
+    }
+
+    @Override
+    protected void beforeInit() {
+        executeStatement("DROP TYPE IF EXISTS user_role_name;");
+        executeStatement("CREATE TYPE user_role_name AS ENUM ('ROLE_ADMIN', 'ROLE_USER');");
+    }
+
+    @Test
+    public void testRoundTripWithCustomToString() {
+        UserRole[] userRoles = {UserRole.ROLE_ADMIN, UserRole.ROLE_USER};
+
+        doInJPA(entityManager -> {
+            UserAccount account = new UserAccount();
+            account.setUsername("vladmihalcea.com");
+            account.setRoles(userRoles);
+            entityManager.persist(account);
+        });
+
+        doInJPA(entityManager -> {
+            UserAccount singleResult = entityManager
+                .createQuery(
+                    "select ua " +
+                    "from UserAccountNameTest ua " +
+                    "where ua.username = :username", UserAccount.class)
+                .setParameter("username", "vladmihalcea.com")
+                .getSingleResult();
+
+            assertArrayEquals(userRoles, singleResult.getRoles());
+        });
+    }
+
+    public enum UserRole {
+        ROLE_ADMIN,
+        ROLE_USER;
+
+        @Override
+        public String toString() {
+            return name().replace("ROLE_", "");
+        }
+    }
+
+    @Entity(name = "UserAccountNameTest")
+    @Table(name = "users_name_test")
+    public static class UserAccount {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String username;
+
+        @Type(
+            value = EnumArrayType.class,
+            parameters = @org.hibernate.annotations.Parameter(
+                name = "sql_array_type",
+                value = "user_role_name"
+            )
+        )
+        @Column(
+            name = "roles",
+            columnDefinition = "user_role_name[]"
+        )
+        private UserRole roles[];
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public UserRole[] getRoles() {
+            return roles;
+        }
+
+        public void setRoles(UserRole[] roles) {
+            this.roles = roles;
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/array/internal/EnumArrayTypeDescriptor.java
@@ -1,5 +1,7 @@
 package io.hypersistence.utils.hibernate.type.array.internal;
 
+import org.hibernate.type.descriptor.WrapperOptions;
+
 import java.util.Properties;
 
 /**
@@ -28,5 +30,18 @@ public class EnumArrayTypeDescriptor
     public void setParameterValues(Properties parameters) {
         sqlArrayType = parameters.getProperty(AbstractArrayType.SQL_ARRAY_TYPE);
         super.setParameterValues(parameters);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public <X> X unwrap(Enum[] value, Class<X> type, WrapperOptions options) {
+        if (value == null) {
+            return null;
+        }
+        String[] names = new String[value.length];
+        for (int i = 0; i < value.length; i++) {
+            names[i] = value[i] == null ? null : value[i].name();
+        }
+        return (X) names;
     }
 }

--- a/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
+++ b/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/type/array/PostgreSQLEnumArrayTypeNameTest.java
@@ -1,0 +1,110 @@
+package io.hypersistence.utils.hibernate.type.array;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests that EnumArrayType correctly persists enums by their name()
+ * even when toString() returns a different value.
+ */
+public class PostgreSQLEnumArrayTypeNameTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[]{
+                UserAccount.class
+        };
+    }
+
+    @Override
+    protected void beforeInit() {
+        executeStatement("DROP TYPE IF EXISTS user_role_name;");
+        executeStatement("CREATE TYPE user_role_name AS ENUM ('ROLE_ADMIN', 'ROLE_USER');");
+    }
+
+    @Test
+    public void testRoundTripWithCustomToString() {
+        UserRole[] userRoles = {UserRole.ROLE_ADMIN, UserRole.ROLE_USER};
+
+        doInJPA(entityManager -> {
+            UserAccount account = new UserAccount();
+            account.setUsername("vladmihalcea.com");
+            account.setRoles(userRoles);
+            entityManager.persist(account);
+        });
+
+        doInJPA(entityManager -> {
+            UserAccount singleResult = entityManager
+                .createQuery(
+                    "select ua " +
+                    "from UserAccountNameTest ua " +
+                    "where ua.username = :username", UserAccount.class)
+                .setParameter("username", "vladmihalcea.com")
+                .getSingleResult();
+
+            assertArrayEquals(userRoles, singleResult.getRoles());
+        });
+    }
+
+    public enum UserRole {
+        ROLE_ADMIN,
+        ROLE_USER;
+
+        @Override
+        public String toString() {
+            return name().replace("ROLE_", "");
+        }
+    }
+
+    @Entity(name = "UserAccountNameTest")
+    @Table(name = "users_name_test")
+    public static class UserAccount {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String username;
+
+        @Type(
+            value = EnumArrayType.class,
+            parameters = @org.hibernate.annotations.Parameter(
+                name = "sql_array_type",
+                value = "user_role_name"
+            )
+        )
+        @Column(
+            name = "roles",
+            columnDefinition = "user_role_name[]"
+        )
+        private UserRole roles[];
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public UserRole[] getRoles() {
+            return roles;
+        }
+
+        public void setRoles(UserRole[] roles) {
+            this.roles = roles;
+        }
+    }
+}


### PR DESCRIPTION
When using `EnumArrayType` with an enum where `name()` and `toString()` differ, the enum can't be persisted or read (depending on the definition) anymore, as `EnumArrayType` persists via `toString()` but reads via enum's `valueOf()` which uses `name()`.