### PR TITLE
Fix broken Javadoc {@code} tags in JsonType

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
@@ -30,8 +30,8 @@ import java.lang.reflect.Type;
  * like in the following example:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "VARCHAR2")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "VARCHAR2")}
  * </pre>
  * <p>
  * For more details about how to use the {@link JsonType}, check out <a href="https://vladmihalcea.com/how-to-map-json-objects-using-generic-hibernate-types/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
@@ -44,8 +44,8 @@ import java.lang.reflect.Type;
  * using the JPA {@link jakarta.persistence.Column#columnDefinition()} attribute, like this:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "BLOB")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "BLOB")}
  * </pre>
  * @author Vlad Mihalcea
  */

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
@@ -30,8 +30,8 @@ import java.lang.reflect.Type;
  * like in the following example:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "VARCHAR2")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "VARCHAR2")}
  * </pre>
  * <p>
  * For more details about how to use the {@link JsonType}, check out <a href="https://vladmihalcea.com/how-to-map-json-objects-using-generic-hibernate-types/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
@@ -44,8 +44,8 @@ import java.lang.reflect.Type;
  * using the JPA {@link jakarta.persistence.Column#columnDefinition()} attribute, like this:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "BLOB")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "BLOB")}
  * </pre>
  * @author Vlad Mihalcea
  */

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
@@ -30,8 +30,8 @@ import java.lang.reflect.Type;
  * like in the following example:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "VARCHAR2")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "VARCHAR2")}
  * </pre>
  * <p>
  * For more details about how to use the {@link JsonType}, check out <a href="https://vladmihalcea.com/how-to-map-json-objects-using-generic-hibernate-types/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
@@ -44,8 +44,8 @@ import java.lang.reflect.Type;
  * using the JPA {@link jakarta.persistence.Column#columnDefinition()} attribute, like this:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "BLOB")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "BLOB")}
  * </pre>
  * @author Vlad Mihalcea
  */

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/json/JsonType.java
@@ -30,8 +30,8 @@ import java.lang.reflect.Type;
  * like in the following example:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "VARCHAR2")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "VARCHAR2")}
  * </pre>
  * <p>
  * For more details about how to use the {@link JsonType}, check out <a href="https://vladmihalcea.com/how-to-map-json-objects-using-generic-hibernate-types/">this article</a> on <a href="https://vladmihalcea.com/">vladmihalcea.com</a>.
@@ -44,8 +44,8 @@ import java.lang.reflect.Type;
  * using the JPA {@link jakarta.persistence.Column#columnDefinition()} attribute, like this:
  * </p>
  * <pre>
- * {@code @Type(}JsonType.class)
- * {@code @Column(}columnDefinition = "BLOB")
+ * {@code @Type(JsonType.class)}
+ * {@code @Column(columnDefinition = "BLOB")}
  * </pre>
  * @author Vlad Mihalcea
  */


### PR DESCRIPTION
## Summary

- Fix broken `{@code}` tags in `JsonType` Javadoc across all four Hibernate modules (63, 70, 71, 73)
- The `{@code}` tags in annotation code examples were prematurely closed (e.g., `{@code @Type(}JsonType.class)` instead of `{@code @Type(JsonType.class)}`), causing incorrect rendering in the generated Javadoc documentation

## Changes

**Before (broken rendering):**
```java
 * {@code @Type(}JsonType.class)
 * {@code @Column(}columnDefinition = "VARCHAR2")
```

**After (correct rendering):**
```java
 * {@code @Type(JsonType.class)}
 * {@code @Column(columnDefinition = "VARCHAR2")}
```

### Files changed
- `hypersistence-utils-hibernate-63/.../JsonType.java`
- `hypersistence-utils-hibernate-70/.../JsonType.java`
- `hypersistence-utils-hibernate-71/.../JsonType.java`
- `hypersistence-utils-hibernate-73/.../JsonType.java`