### PR TITLE
Upgrade Testcontainers to the 2.0.4 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,28 +109,28 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>oracle-xe</artifactId>
+            <artifactId>testcontainers-oracle-xe</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mssqlserver</artifactId>
+            <artifactId>testcontainers-mssqlserver</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -415,7 +415,7 @@
         <mockito.version>1.8.5</mockito.version>
         <datasource-proxy.version>1.6</datasource-proxy.version>
 
-        <testcontainers.version>1.17.3</testcontainers.version>
+        <testcontainers.version>2.0.4</testcontainers.version>
         <hsqldb.version>2.2.8</hsqldb.version>
         <h2.version>1.4.200</h2.version>
         <postgresql.version>42.4.1</postgresql.version>


### PR DESCRIPTION
This PR upgrades testcontainers from `1.17.3` to `2.0.4`.

With `1.17.3` I ran into problems with docker version 29.4.0 (running under Ubuntu 24.04.4 LTS):

```
ERROR [Alice]: o.t.d.DockerClientProviderStrategy - Could not find a valid Docker environment. Please check configuration. Attempted configurations were: ERROR [Alice]: o.t.d.DockerClientProviderStrategy - UnixSocketClientProviderStrategy: failed with exception BadRequestException (Status 400: {"message":"client version 1.32 is too old. Minimum supported API version is 1.40, please upgrade your client to a newer version"} )
```

What helped: Creating a file `~/.docker-java.properties` containing `api.version=1.44`.

But with testcontainers `2.0.4` this file is not needed.

Another suggestion: You should point out that `testcontainers.reuse.enable=true` can or should be added to `~/.testcontainers.properties`, as this will make the tests run more efficiently in terms of resource usage.
