### PR TITLE
Fix merge method JavaDocs

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
@@ -82,7 +82,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -115,7 +115,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
@@ -100,7 +100,7 @@ public interface HibernateRepository<T> {
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -133,7 +133,7 @@ public interface HibernateRepository<T> {
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
@@ -82,7 +82,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -115,7 +115,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
@@ -100,7 +100,7 @@ public interface HibernateRepository<T> {
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -133,7 +133,7 @@ public interface HibernateRepository<T> {
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
@@ -82,7 +82,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -115,7 +115,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
@@ -100,7 +100,7 @@ public interface HibernateRepository<T> {
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -133,7 +133,7 @@ public interface HibernateRepository<T> {
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/spring/repository/BaseJpaRepository.java
@@ -82,7 +82,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -115,7 +115,7 @@ public interface BaseJpaRepository<T, ID> extends Repository<T, ID>, QueryByExam
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/spring/repository/HibernateRepository.java
@@ -100,7 +100,7 @@ public interface HibernateRepository<T> {
     <S extends T> List<S> persistAllAndFlush(Iterable<S> entities);
 
     /**
-     * The persist method allows you to pass the provided entity to the {@code merge} method of the
+     * The merge method allows you to pass the provided entity to the {@code merge} method of the
      * underlying JPA {@code EntityManager}.
      *
      * @param entity entity to merge
@@ -133,7 +133,7 @@ public interface HibernateRepository<T> {
      * The mergeAllAndFlush method allows you to pass the provided entities to the {@code merge} method of the
      * underlying JPA {@code EntityManager} and call {@code flush} afterwards.
      *
-     * @param entities entities to persist
+     * @param entities entities to merge
      * @param <S>    entity type
      * @return entities
      */


### PR DESCRIPTION
Corrected the JavaDoc in BaseJpaRepository and HibernateRepository where the merge methods incorrectly referred to themselves as 'persist'. Updated `@param` descriptions to correctly refer to 'merge' instead of 'persist'.