### PR TITLE
ObjectMapperJsonSerializer handle java.lang.Optional values

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -2,9 +2,9 @@ package io.hypersistence.utils.hibernate.type.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.hibernate.internal.util.SerializationHelper;
-import org.hibernate.type.SerializationException;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * @author Vlad Mihalcea
@@ -18,6 +18,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         }
         if (object instanceof JsonNode) {
             return (T) ((JsonNode) object).deepCopy();
+        }
+        if (object instanceof Optional) {
+            Optional<?> optional = (Optional<?>) object;
+            return (T) optional.map(this::clone);
         }
         try {
             if (object instanceof Serializable) {

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -165,6 +165,30 @@ public class ObjectMapperJsonSerializerTest {
     }
 
     @Test
+    public void should_clone_optional_of_serializable_object() {
+        Optional<SerializableObject> original = Optional.of(new SerializableObject("value"));
+        Optional<SerializableObject> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_empty_optional() {
+        Optional<?> original = Optional.empty();
+        Optional<?> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+    }
+
+    @Test
+    public void should_clone_optional_of_non_serializable_object() {
+        Optional<NonSerializableObject> original = Optional.of(new NonSerializableObject("value"));
+        try {
+            serializer.clone(original);
+            fail("Should throw exception");
+        } catch (Exception expected) {}
+    }
+
+    @Test
     public void should_clone_mixed_lists() {
         Map<String, List<String>> map = new LinkedHashMap<>();
         List<String> arrayList = new ArrayList<>();

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -2,9 +2,9 @@ package io.hypersistence.utils.hibernate.type.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.hibernate.internal.util.SerializationHelper;
-import org.hibernate.type.SerializationException;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * @author Vlad Mihalcea
@@ -18,6 +18,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         }
         if (object instanceof JsonNode) {
             return (T) ((JsonNode) object).deepCopy();
+        }
+        if (object instanceof Optional) {
+            Optional<?> optional = (Optional<?>) object;
+            return (T) optional.map(this::clone);
         }
         try {
             if (object instanceof Serializable) {

--- a/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hypersistence-utils-hibernate-70/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -166,6 +166,30 @@ public class ObjectMapperJsonSerializerTest {
     }
 
     @Test
+    public void should_clone_optional_of_serializable_object() {
+        Optional<SerializableObject> original = Optional.of(new SerializableObject("value"));
+        Optional<SerializableObject> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_empty_optional() {
+        Optional<?> original = Optional.empty();
+        Optional<?> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+    }
+
+    @Test
+    public void should_clone_optional_of_non_serializable_object() {
+        Optional<NonSerializableObject> original = Optional.of(new NonSerializableObject("value"));
+        try {
+            serializer.clone(original);
+            fail("Should throw exception");
+        } catch (Exception expected) {}
+    }
+
+    @Test
     public void should_clone_mixed_lists() {
         Map<String, List<String>> map = new LinkedHashMap<>();
         List<String> arrayList = new ArrayList<>();

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -2,9 +2,9 @@ package io.hypersistence.utils.hibernate.type.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.hibernate.internal.util.SerializationHelper;
-import org.hibernate.type.SerializationException;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * @author Vlad Mihalcea
@@ -18,6 +18,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         }
         if (object instanceof JsonNode) {
             return (T) ((JsonNode) object).deepCopy();
+        }
+        if (object instanceof Optional) {
+            Optional<?> optional = (Optional<?>) object;
+            return (T) optional.map(this::clone);
         }
         try {
             if (object instanceof Serializable) {

--- a/hypersistence-utils-hibernate-71/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hypersistence-utils-hibernate-71/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -165,6 +165,30 @@ public class ObjectMapperJsonSerializerTest {
     }
 
     @Test
+    public void should_clone_optional_of_serializable_object() {
+        Optional<SerializableObject> original = Optional.of(new SerializableObject("value"));
+        Optional<SerializableObject> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_empty_optional() {
+        Optional<?> original = Optional.empty();
+        Optional<?> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+    }
+
+    @Test
+    public void should_clone_optional_of_non_serializable_object() {
+        Optional<NonSerializableObject> original = Optional.of(new NonSerializableObject("value"));
+        try {
+            serializer.clone(original);
+            fail("Should throw exception");
+        } catch (Exception expected) {}
+    }
+
+    @Test
     public void should_clone_mixed_lists() {
         Map<String, List<String>> map = new LinkedHashMap<>();
         List<String> arrayList = new ArrayList<>();

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializer.java
@@ -4,6 +4,7 @@ import org.hibernate.internal.util.SerializationHelper;
 import tools.jackson.databind.JsonNode;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * @author Vlad Mihalcea
@@ -17,6 +18,10 @@ public class ObjectMapperJsonSerializer implements JsonSerializer {
         }
         if (object instanceof JsonNode) {
             return (T) ((JsonNode) object).deepCopy();
+        }
+        if (object instanceof Optional) {
+            Optional<?> optional = (Optional<?>) object;
+            return (T) optional.map(this::clone);
         }
         try {
             if (object instanceof Serializable) {

--- a/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
+++ b/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/type/util/ObjectMapperJsonSerializerTest.java
@@ -165,6 +165,30 @@ public class ObjectMapperJsonSerializerTest {
     }
 
     @Test
+    public void should_clone_optional_of_serializable_object() {
+        Optional<SerializableObject> original = Optional.of(new SerializableObject("value"));
+        Optional<SerializableObject> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+        assertNotSame(original, cloned);
+    }
+
+    @Test
+    public void should_clone_empty_optional() {
+        Optional<?> original = Optional.empty();
+        Optional<?> cloned = serializer.clone(original);
+        assertEquals(original, cloned);
+    }
+
+    @Test
+    public void should_clone_optional_of_non_serializable_object() {
+        Optional<NonSerializableObject> original = Optional.of(new NonSerializableObject("value"));
+        try {
+            serializer.clone(original);
+            fail("Should throw exception");
+        } catch (Exception expected) {}
+    }
+
+    @Test
     public void should_clone_mixed_lists() {
         Map<String, List<String>> map = new LinkedHashMap<>();
         List<String> arrayList = new ArrayList<>();


### PR DESCRIPTION
Using Optional in Serializable classes used by `@Type(JsonType.class)` columns currently throws an error and requires customisation.

Can we consider adding Optional support in the basic ObjectMapperJsonSerializer? I think that, in almost every case, we'll want to serialize the object that's being wrapped by the Optional.

Any concerns with the call being recursive? Arguably it'll help if anyone is doing `Optional<Optional<...>>`, or `Optional<List<...>>` which they definitely shouldn't be :)

Without the changes to the serializer we get:

```
io.hypersistence.utils.hibernate.type.util.NonSerializableObjectException: The JPA specification requires that the entity attributes are Serializable and the [Optional[value]] Object (or its inner child Objects) is not Serializable. The default JsonSerializer does not support JSON object cloning (other than the JsonNode attribute type) because this is a very inefficient operation. If you want to use JSON object cloning, then you can provide your own custom JsonSerializer.

	at io.hypersistence.utils.hibernate.type.util.ObjectMapperJsonSerializer.clone(ObjectMapperJsonSerializer.java:29)
	at io.hypersistence.utils.hibernate.type.util.ObjectMapperJsonSerializerTest
```