### PR TITLE
bump versions hibernate + fix hibernate 7.4.0.Final

### DIFF
--- a/hypersistence-utils-hibernate-63/pom.xml
+++ b/hypersistence-utils-hibernate-63/pom.xml
@@ -213,7 +213,7 @@
         <!--<hibernate.version>6.3.2.Final</hibernate.version>-->
         <!--<hibernate.version>6.4.10.Final</hibernate.version>-->
         <!--<hibernate.version>6.5.3.Final</hibernate.version>-->
-        <hibernate.version>6.6.38.Final</hibernate.version>
+        <hibernate.version>6.6.52.Final</hibernate.version>
 
         <jackson-module.version>2.20.1</jackson-module.version>
         <guava.version>32.1.3-jre</guava.version>

--- a/hypersistence-utils-hibernate-71/pom.xml
+++ b/hypersistence-utils-hibernate-71/pom.xml
@@ -217,7 +217,7 @@
         <maven.compiler.release>${jdk.version}</maven.compiler.release>
         <maven.compiler.testRelease>${jdk-test.version}</maven.compiler.testRelease>
 
-        <hibernate.version>7.2.0.Final</hibernate.version>
+        <hibernate.version>7.2.17.Final</hibernate.version>
         <!--<hibernate.version>7.1.11.Final</hibernate.version>-->
 
         <jackson-module.version>2.20.1</jackson-module.version>

--- a/hypersistence-utils-hibernate-73/pom.xml
+++ b/hypersistence-utils-hibernate-73/pom.xml
@@ -14,6 +14,20 @@
 
     <name>hypersistence-utils-hibernate-73</name>
     <description>Utilities for Spring and Hibernate ORM 7.3</description>
+    
+    <profiles>
+	    <profile>
+	        <id>hibernate-73</id>
+	        <activation>
+	            <property>
+	                <name>hibernate73</name>
+	            </property>
+	        </activation>
+	        <properties>
+	            <hibernate.version>7.3.7.Final</hibernate.version>
+	        </properties>
+	    </profile>
+	</profiles>
 
     <dependencies>
 
@@ -217,7 +231,7 @@
         <maven.compiler.release>${jdk.version}</maven.compiler.release>
         <maven.compiler.testRelease>${jdk-test.version}</maven.compiler.testRelease>
 
-        <hibernate.version>7.3.0.CR1</hibernate.version>
+        <hibernate.version>7.4.0.Final</hibernate.version>
 
         <jackson-module.version>3.0.0</jackson-module.version>
         <guava.version>32.1.3-jre</guava.version>

--- a/hypersistence-utils-hibernate-73/pom.xml
+++ b/hypersistence-utils-hibernate-73/pom.xml
@@ -15,20 +15,6 @@
     <name>hypersistence-utils-hibernate-73</name>
     <description>Utilities for Spring and Hibernate ORM 7.3</description>
     
-    <profiles>
-	    <profile>
-	        <id>hibernate-73</id>
-	        <activation>
-	            <property>
-	                <name>hibernate73</name>
-	            </property>
-	        </activation>
-	        <properties>
-	            <hibernate.version>7.3.7.Final</hibernate.version>
-	        </properties>
-	    </profile>
-	</profiles>
-
     <dependencies>
 
         <dependency>

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/MutableDynamicParameterizedType.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/MutableDynamicParameterizedType.java
@@ -6,13 +6,8 @@ import java.sql.CallableStatement;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import org.checkerframework.checker.initialization.qual.Initialized;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.model.domain.BasicDomainType;
-import org.hibernate.query.sqm.SqmBindableType;
 import org.hibernate.query.sqm.tree.domain.SqmDomainType;
 import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
@@ -24,7 +19,7 @@ import io.hypersistence.utils.hibernate.type.util.Configuration;
 /**
  * @author Vlad Mihalcea
  */
-public class MutableDynamicParameterizedType<T, JDBC extends JdbcType, JAVA extends JavaType<T>> extends MutableType<T, JDBC, JAVA> implements DynamicParameterizedType, BasicDomainType<T>, SqmDomainType<T>,SqmBindableType<T> {
+public class MutableDynamicParameterizedType<T, JDBC extends JdbcType, JAVA extends JavaType<T>> extends MutableType<T, JDBC, JAVA> implements DynamicParameterizedType, BasicDomainType<T>, SqmDomainType<T> {
 
     /**
      * {@inheritDoc}
@@ -77,7 +72,7 @@ public class MutableDynamicParameterizedType<T, JDBC extends JdbcType, JAVA exte
     }
 
 	@Override
-	public @Nullable SqmDomainType<@UnknownKeyFor @NonNull @Initialized T> getSqmType() {
+	public SqmDomainType<T> getSqmType() {
 		return this;
 	}
 }

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/MutableDynamicParameterizedType.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/MutableDynamicParameterizedType.java
@@ -1,23 +1,30 @@
 package io.hypersistence.utils.hibernate.type;
 
-import io.hypersistence.utils.hibernate.type.util.Configuration;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.metamodel.model.domain.BasicDomainType;
-import org.hibernate.type.descriptor.java.JavaType;
-import org.hibernate.type.descriptor.jdbc.JdbcType;
-import org.hibernate.usertype.DynamicParameterizedType;
-import org.hibernate.usertype.ParameterizedType;
+import static jakarta.persistence.metamodel.Type.PersistenceType.BASIC;
 
 import java.sql.CallableStatement;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import static jakarta.persistence.metamodel.Type.PersistenceType.BASIC;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.metamodel.model.domain.BasicDomainType;
+import org.hibernate.query.sqm.SqmBindableType;
+import org.hibernate.query.sqm.tree.domain.SqmDomainType;
+import org.hibernate.type.descriptor.java.JavaType;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+import org.hibernate.usertype.DynamicParameterizedType;
+import org.hibernate.usertype.ParameterizedType;
+
+import io.hypersistence.utils.hibernate.type.util.Configuration;
 
 /**
  * @author Vlad Mihalcea
  */
-public class MutableDynamicParameterizedType<T, JDBC extends JdbcType, JAVA extends JavaType<T>> extends MutableType<T, JDBC, JAVA> implements DynamicParameterizedType, BasicDomainType<T>{
+public class MutableDynamicParameterizedType<T, JDBC extends JdbcType, JAVA extends JavaType<T>> extends MutableType<T, JDBC, JAVA> implements DynamicParameterizedType, BasicDomainType<T>, SqmDomainType<T>,SqmBindableType<T> {
 
     /**
      * {@inheritDoc}
@@ -68,4 +75,9 @@ public class MutableDynamicParameterizedType<T, JDBC extends JdbcType, JAVA exte
     public T extract(CallableStatement statement, String paramName, SharedSessionContractImplementor session) throws SQLException {
         return getJdbcTypeDescriptor().getExtractor(getJavaTypeDescriptor()).extract(statement, paramName, session);
     }
+
+	@Override
+	public @Nullable SqmDomainType<@UnknownKeyFor @NonNull @Initialized T> getSqmType() {
+		return this;
+	}
 }


### PR DESCRIPTION
Hi @vladmihalcea , thanks for taking a look at this PR.

This change updates the Hibernate versions across the affected modules and adds a fallback option for running the tests against Hibernate 7.3 with module hypersistence-utils-hibernate-73 when needed. It also includes the small type-related adjustment required for Hibernate 7.4 compatibility.

- updated hypersistence-utils-hibernate-63 from Hibernate 6.6.38.Final to 6.6.52.Final
- updated hypersistence-utils-hibernate-71 from Hibernate 7.2.0.Final to 7.2.17.Final
- updated hypersistence-utils-hibernate-73 from Hibernate 7.3.0.CR1 to 7.4.0.Final
- added a fallback profile for tests targeting Hibernate 7.3.7.Final in the hypersistence-utils-hibernate-73 module
   the fallback can be enabled with -Dhibernate73
- adjusted MutableDynamicParameterizedType for compatibility with Hibernate 7.4