### PR TITLE
#854 Use CONNECT BY LEVEL instead of CONNECT BY ROWNUM

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
@@ -88,7 +88,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <pre><code>
  * SELECT seq_xxx.nextval
  * FROM dual
- * CONNECT BY rownum &lt;= ?
+ * CONNECT BY level &lt;= ?
  * </code></pre>
  *
  * <h3>SQL Server</h3>
@@ -240,7 +240,7 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
 
     private static String buildSelect(String nextValString, Dialect dialect) {
         if (dialect instanceof org.hibernate.dialect.OracleDialect) {
-            return "SELECT " + nextValString + " FROM dual CONNECT BY rownum <= ?";
+            return "SELECT " + nextValString + " FROM dual CONNECT BY level <= ?";
         }
         if (dialect instanceof org.hibernate.dialect.SQLServerDialect) {
             // No RECURSIVE

--- a/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
+++ b/hypersistence-utils-hibernate-70/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
@@ -85,7 +85,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <pre><code>
  * SELECT seq_xxx.nextval
  * FROM dual
- * CONNECT BY rownum &lt;= ?
+ * CONNECT BY level &lt;= ?
  * </code></pre>
  *
  * <h3>SQL Server</h3>
@@ -237,7 +237,7 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
 
     private static String buildSelect(String nextValString, Dialect dialect) {
         if (dialect instanceof org.hibernate.dialect.OracleDialect) {
-            return "SELECT " + nextValString + " FROM dual CONNECT BY rownum <= ?";
+            return "SELECT " + nextValString + " FROM dual CONNECT BY level <= ?";
         }
         if (dialect instanceof org.hibernate.dialect.SQLServerDialect) {
             // No RECURSIVE

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
@@ -85,7 +85,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <pre><code>
  * SELECT seq_xxx.nextval
  * FROM dual
- * CONNECT BY rownum &lt;= ?
+ * CONNECT BY level &lt;= ?
  * </code></pre>
  *
  * <h3>SQL Server</h3>
@@ -237,7 +237,7 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
 
     private static String buildSelect(String nextValString, Dialect dialect) {
         if (dialect instanceof org.hibernate.dialect.OracleDialect) {
-            return "SELECT " + nextValString + " FROM dual CONNECT BY rownum <= ?";
+            return "SELECT " + nextValString + " FROM dual CONNECT BY level <= ?";
         }
         if (dialect instanceof org.hibernate.dialect.SQLServerDialect) {
             // No RECURSIVE

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
@@ -86,7 +86,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <pre><code>
  * SELECT seq_xxx.nextval
  * FROM dual
- * CONNECT BY rownum &lt;= ?
+ * CONNECT BY level &lt;= ?
  * </code></pre>
  *
  * <h3>SQL Server</h3>
@@ -237,7 +237,7 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
 
     private static String buildSelect(String nextValString, Dialect dialect) {
         if (dialect instanceof org.hibernate.dialect.OracleDialect) {
-            return "SELECT " + nextValString + " FROM dual CONNECT BY rownum <= ?";
+            return "SELECT " + nextValString + " FROM dual CONNECT BY level <= ?";
         }
         if (dialect instanceof org.hibernate.dialect.SQLServerDialect) {
             // No RECURSIVE


### PR DESCRIPTION
Fix the Oracle case of BatchSequenceGenerator, by using LEVEL instead of ROWNUM.

The SELECT sequence.NEXTVAL FROM dual CONNECT by rownum <= ? was working more or less by accident on older versions of Oracle and no longer reliably works on Oracle 26.
It works if optimizer produces execution plan with COUNT STOPKEY capping the CONNECT BY WITHOUT FILTERING (which is the case of e.g. Oracle <23). However if the optimizer chooses different plan the query with rownum will run off and fails with "ORA-30009: Not enough memory for CONNECT BY operation".

Fixes #854