### PR TITLE
Improve BatchSequenceGenerator sequence name strategy and align it with SequenceStyleGenerator

### DIFF
--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequence.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequence.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.hibernate.annotations.IdGeneratorType;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.id.enhanced.ImplicitDatabaseObjectNamingStrategy;
 
 /**
  * Meta annotation to use {@link BatchSequenceGenerator} as an identifier generator.
@@ -22,10 +24,14 @@ public @interface BatchSequence {
 
     /**
      * Returns the name of the sequence to use.
+     * <p>
+     * If omitted (empty or {@code null} then {@link ImplicitDatabaseObjectNamingStrategy}
+     * is used to derive the name.
      * 
      * @return the name of the sequence to use
+     * @see AvailableSettings#ID_DB_STRUCTURE_NAMING_STRATEGY
      */
-    String name();
+    String name() default "";
 
     /**
      *  Returns how many sequence values to fetch at once.

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
@@ -18,12 +18,16 @@ import org.hibernate.id.BulkInsertionCapableIdentifierGenerator;
 import org.hibernate.id.Configurable;
 import org.hibernate.id.IdentifierGenerationException;
 import org.hibernate.id.PersistentIdentifierGenerator;
+import org.hibernate.id.enhanced.ImplicitDatabaseObjectNamingStrategy;
 import org.hibernate.id.enhanced.Optimizer;
 import org.hibernate.id.enhanced.SequenceStructure;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.models.spi.TypeDetails;
 import org.hibernate.models.spi.TypeDetails.Kind;
 import org.hibernate.resource.jdbc.ResourceRegistry;
+import org.hibernate.service.ServiceRegistry;
+
+import static org.hibernate.id.IdentifierGeneratorHelper.getNamingStrategy;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -141,7 +145,10 @@ import java.util.concurrent.locks.ReentrantLock;
 public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGenerator, PersistentIdentifierGenerator, Configurable {
 
     /**
-     * Indicates the name of the sequence to use, mandatory.
+     * Indicates the name of the sequence to use, optional.
+     * <p>
+     * If omitted (empty or {@code null} then {@link ImplicitDatabaseObjectNamingStrategy}
+     * is used to derive the name.
      * 
      * @deprecated use {@link BatchSequence}
      */
@@ -177,6 +184,10 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
 
     private IdentifierPool identifierPool;
 
+    private BatchSequence annotation;
+
+    private GeneratorCreationContext context;
+
     /**
      * Called when {@link BatchSequence} is used.
      * 
@@ -184,31 +195,32 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
      */
     public BatchSequenceGenerator(BatchSequence annotation,
                     GeneratorCreationContext context) {
-      JdbcEnvironment jdbcEnvironment = context.getServiceRegistry().getService(JdbcEnvironment.class);
-      this.sequenceName = determineSequenceName(annotation, jdbcEnvironment);
-      this.fetchSize = annotation.fetchSize();
-      
-      Class<?> type = getType(context);
-      this.identifierExtractor = IdentifierExtractor.getIdentifierExtractor(type);
-      this.sequenceStructure = this.buildSequenceStructure(type, sequenceName);
+        this.annotation = annotation;
+        this.context = context;
     }
 
     @Override
     public void configure(GeneratorCreationContext creationContext, Properties params)
                     throws MappingException {
 
-        if (this.sequenceName == null) {
+        ServiceRegistry serviceRegistry = creationContext.getServiceRegistry();
+        JdbcEnvironment jdbcEnvironment = serviceRegistry.getService(JdbcEnvironment.class);
+        Class<?> type;
+        if (this.annotation == null) {
             // not initialized in constructor
-            JdbcEnvironment jdbcEnvironment = creationContext.getServiceRegistry().getService(JdbcEnvironment.class);
-            
-            this.sequenceName = determineSequenceName(params, jdbcEnvironment);
+            this.sequenceName = determineSequenceName(params, serviceRegistry, jdbcEnvironment);
             this.fetchSize = determineFetchSize(params);
 
-            Class<?> numberType = creationContext.getType().getReturnedClass();
-            this.identifierExtractor = IdentifierExtractor.getIdentifierExtractor(numberType);
-            this.sequenceStructure = this.buildSequenceStructure(numberType, sequenceName);
-
+            type = creationContext.getType().getReturnedClass();
+        } else {
+            // annotation constructor used
+            this.sequenceName = determineSequenceName(params, annotation, serviceRegistry, jdbcEnvironment);
+            this.fetchSize = annotation.fetchSize();
+            
+            type = getType(context);
         }
+        this.identifierExtractor = IdentifierExtractor.getIdentifierExtractor(type);
+        this.sequenceStructure = this.buildSequenceStructure(type, sequenceName);
     }
 
     private static Class<?> getType(GeneratorCreationContext context) {
@@ -291,13 +303,10 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
 	 * @return The sequence name
 	 */
 	private static QualifiedName determineSequenceName(
-			Properties params, JdbcEnvironment jdbcEnv) {
+			Properties params, ServiceRegistry serviceRegistry, JdbcEnvironment jdbcEnv) {
         String sequenceName = params.getProperty(SEQUENCE_PARAM);
-        if (sequenceName == null) {
-            throw new MappingException("no sequence name specified");
-        }
 
-        if(sequenceName.contains(".")) {
+        if(sequenceName != null && sequenceName.contains(".")) {
             return QualifiedNameParser.INSTANCE.parse(sequenceName);
         }
 
@@ -305,21 +314,24 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
         final Identifier catalog = identifierHelper.toIdentifier(params.getProperty(CATALOG));
         final Identifier schema =  identifierHelper.toIdentifier(params.getProperty(SCHEMA));
 
-        return new QualifiedSequenceName(
-            catalog,
-            schema,
-            identifierHelper.toIdentifier( sequenceName )
-            );
+        if (sequenceName != null && !sequenceName.isEmpty()) {
+            // we have an explicit name, use it
+            return new QualifiedSequenceName(
+                catalog,
+                schema,
+                identifierHelper.toIdentifier( sequenceName )
+                );
+        } else {
+            // otherwise, determine an implicit name to use
+            return getNamingStrategy(params, serviceRegistry).determineSequenceName(catalog, schema, params, serviceRegistry);
+        }
     }
 
     private static QualifiedName determineSequenceName(
-                    BatchSequence annotation, JdbcEnvironment jdbcEnv) {
+                    Properties params, BatchSequence annotation, ServiceRegistry serviceRegistry, JdbcEnvironment jdbcEnv) {
         String sequenceName = annotation.name();
-        if (sequenceName == null) {
-            throw new MappingException("no sequence name specified");
-        }
 
-        if(sequenceName.contains(".")) {
+        if(sequenceName != null && sequenceName.contains(".")) {
             return QualifiedNameParser.INSTANCE.parse(sequenceName);
         }
 
@@ -327,11 +339,17 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
         final Identifier catalog = identifierHelper.toIdentifier(annotation.catalog());
         final Identifier schema =  identifierHelper.toIdentifier(annotation.schema());
 
-        return new QualifiedSequenceName(
-                        catalog,
-                        schema,
-                        identifierHelper.toIdentifier( sequenceName )
-                        );
+        if (sequenceName != null && !sequenceName.isEmpty()) {
+            // we have an explicit name, use it
+            return new QualifiedSequenceName(
+                catalog,
+                schema,
+                identifierHelper.toIdentifier( sequenceName )
+                );
+        } else {
+            // otherwise, determine an implicit name to use
+            return getNamingStrategy(params, serviceRegistry).determineSequenceName(catalog, schema, params, serviceRegistry);
+        }
     }
 
     private static int determineFetchSize(Properties params) {

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/id/BatchSequenceGenerator.java
@@ -23,6 +23,7 @@ import org.hibernate.id.enhanced.SequenceStructure;
 import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.models.spi.TypeDetails;
 import org.hibernate.models.spi.TypeDetails.Kind;
+import org.hibernate.resource.jdbc.ResourceRegistry;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -377,17 +378,29 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
                     throws HibernateException {
         JdbcCoordinator coordinator = session.getJdbcCoordinator();
         List<Serializable> identifiers = new ArrayList<>(this.fetchSize);
-        try (PreparedStatement statement = coordinator.getStatementPreparer().prepareStatement(this.select)) {
+        PreparedStatement statement = coordinator.getStatementPreparer().prepareStatement(this.select);
+        ResourceRegistry registry = coordinator.getLogicalConnection().getResourceRegistry();
+        try {
             statement.setFetchSize(this.fetchSize);
             statement.setInt(1, this.fetchSize);
-            try (ResultSet resultSet = coordinator.getResultSetReturn().extract(statement, this.select)) {
+            ResultSet resultSet = coordinator.getResultSetReturn().extract(statement, this.select);
+            try {
                 while (resultSet.next()) {
                     identifiers.add(this.identifierExtractor.extractIdentifier(resultSet));
+                }
+            } finally {
+                try {
+                    registry.release(resultSet, statement);
+                } catch (Throwable ignore) {
+                    // intentionally empty
                 }
             }
         } catch (SQLException e) {
             throw session.getJdbcServices().getSqlExceptionHelper().convert(
                             e, "could not get next sequence value", this.select);
+        } finally {
+            registry.release(statement);
+            coordinator.afterStatementExecution();
         }
         if (identifiers.size() != this.fetchSize) {
             throw new IdentifierGenerationException("expected " + this.fetchSize + " values from " + this.getSequenceName()

--- a/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/id/AbstractBatchSequenceGeneratorTest.java
+++ b/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/id/AbstractBatchSequenceGeneratorTest.java
@@ -2,15 +2,23 @@ package io.hypersistence.utils.hibernate.id;
 
 import io.hypersistence.utils.hibernate.util.AbstractTest;
 import io.hypersistence.utils.test.providers.DataSourceProvider;
+import io.hypersistence.utils.test.transaction.EntityManagerTransactionConsumer;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import net.ttddyy.dsproxy.QueryCount;
 import net.ttddyy.dsproxy.QueryCountHolder;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.QualifiedName;
+import org.hibernate.boot.model.relational.QualifiedSequenceName;
 import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.id.enhanced.ImplicitDatabaseObjectNamingStrategy;
+import org.hibernate.service.ServiceRegistry;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -37,13 +45,14 @@ public abstract class AbstractBatchSequenceGeneratorTest extends AbstractTest {
         properties.put(AvailableSettings.STATEMENT_BATCH_SIZE, BATCH_SIZE);
         properties.put(AvailableSettings.ORDER_UPDATES, true);
         properties.put(AvailableSettings.ORDER_INSERTS, true);
+        properties.put(AvailableSettings.ID_DB_STRUCTURE_NAMING_STRATEGY, HardCodedSequenceName.class.getName());
     }
 
     @Test
     public void test() {
 
         QueryCountHolder.clear();
-        doInJPA(entityManager -> {
+        doInJPA((EntityManagerTransactionConsumer) entityManager -> {
             for (int i = 0; i < BATCH_SIZE; i++) {
                 Post post = new Post();
 
@@ -90,7 +99,6 @@ public abstract class AbstractBatchSequenceGeneratorTest extends AbstractTest {
 
         @Id
         @BatchSequence(
-            name = "SEQ_PARENT_ID",
             fetchSize = BATCH_SIZE
         )
         private Long id;
@@ -114,6 +122,24 @@ public abstract class AbstractBatchSequenceGeneratorTest extends AbstractTest {
             this.title = title;
             return this;
         }
+    }
+
+    public static class HardCodedSequenceName implements ImplicitDatabaseObjectNamingStrategy {
+
+        @Override
+        public QualifiedName determineSequenceName(Identifier catalogName,
+                        Identifier schemaName, Map<?, ?> configValues,
+                        ServiceRegistry serviceRegistry) {
+            return new QualifiedSequenceName(catalogName, schemaName, Identifier.toIdentifier("SEQ_PARENT_ID"));
+        }
+
+        @Override
+        public QualifiedName determineTableName(Identifier catalogName,
+                        Identifier schemaName, Map<?, ?> configValues,
+                        ServiceRegistry serviceRegistry) {
+            throw new IllegalArgumentException("BatchSequenceGeneratorTest is not table based");
+        }
+
     }
 
 }


### PR DESCRIPTION
This PR contains two improvements for `BatchSequenceGenerator` split into two commits

1. Align the code in `BatchSequenceGenerator` with `SequenceStyleGenerator`, use code similar to `SequenceStructure#buildCallback`. Specifically
   - close result set using `ResourceRegistry#release`
   - close statement using `ResourceRegistry#release`
   - invoke `JdbcCoordinator#afterStatementExecution`
1. Make sequence name optional for `BatchSequenceGenerator`, if the sequence name is missing use `ImplicitDatabaseObjectNamingStrategy` to derive the name. This makes `@BatchSequence` even easier to use if you use a naming convention for your sequence names.