### PR TITLE
Add PostgreSQL macaddr type support

### DIFF
--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -5,6 +5,7 @@ import io.hypersistence.utils.common.StringUtils;
 import io.hypersistence.utils.hibernate.type.basic.Iso8601MonthType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLHStoreType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLInetType;
+import io.hypersistence.utils.hibernate.type.basic.PostgreSQLMacAddressType;
 import io.hypersistence.utils.hibernate.type.interval.OracleIntervalDayToSecondType;
 import io.hypersistence.utils.hibernate.type.interval.PostgreSQLPeriodType;
 import io.hypersistence.utils.hibernate.type.json.JsonNodeStringType;
@@ -95,6 +96,7 @@ public class HibernateTypesContributor implements TypeContributor {
             /* Specific-types */
             contributeType(typeContributions, PostgreSQLHStoreType.INSTANCE, typeFilter);
             contributeType(typeContributions, PostgreSQLInetType.INSTANCE, typeFilter);
+            contributeType(typeContributions, PostgreSQLMacAddressType.INSTANCE, typeFilter);
             contributeType(typeContributions, PostgreSQLRangeType.INSTANCE, typeFilter);
 
             if(ReflectionUtils.getClassOrNull("com.google.common.collect.Range") != null) {

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/basic/MacAddress.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/basic/MacAddress.java
@@ -1,0 +1,39 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * The {@link MacAddress} object type is used to represent a PostgreSQL {@code macaddr} (MAC address) column.
+ * <p>
+ * The value is stored using the canonical representation returned by PostgreSQL (e.g. {@code 08:00:2b:01:02:03}).
+ */
+public class MacAddress implements Serializable {
+
+    private final String address;
+
+    public MacAddress(String address) {
+        this.address = address;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return Objects.equals(address, MacAddress.class.cast(o).address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
+    }
+
+    @Override
+    public String toString() {
+        return address;
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressType.java
+++ b/hypersistence-utils-hibernate-63/src/main/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressType.java
@@ -1,0 +1,56 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import io.hypersistence.utils.hibernate.type.ImmutableType;
+import io.hypersistence.utils.hibernate.type.util.Configuration;
+import io.hypersistence.utils.common.ReflectionUtils;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link MacAddress} object type to a PostgreSQL {@code macaddr} column type.
+ */
+public class PostgreSQLMacAddressType extends ImmutableType<MacAddress> {
+
+    public static final PostgreSQLMacAddressType INSTANCE = new PostgreSQLMacAddressType();
+
+    public PostgreSQLMacAddressType() {
+        super(MacAddress.class);
+    }
+
+    public PostgreSQLMacAddressType(org.hibernate.type.spi.TypeBootstrapContext typeBootstrapContext) {
+        super(MacAddress.class, new Configuration(typeBootstrapContext.getConfigurationSettings()));
+    }
+
+    @Override
+    public int getSqlType() {
+        return Types.OTHER;
+    }
+
+    @Override
+    public MacAddress get(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        String macAddress = rs.getString(position);
+        return (macAddress != null) ? new MacAddress(macAddress) : null;
+    }
+
+    @Override
+    public void set(PreparedStatement st, MacAddress value, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", "macaddr");
+            ReflectionUtils.invokeSetter(holder, "value", value.getAddress());
+            st.setObject(index, holder);
+        }
+    }
+
+    @Override
+    public MacAddress fromStringValue(CharSequence sequence) throws HibernateException {
+        return sequence != null ? new MacAddress((String) sequence) : null;
+    }
+}

--- a/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressTypeTest.java
+++ b/hypersistence-utils-hibernate-63/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressTypeTest.java
@@ -1,0 +1,128 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgreSQLMacAddressTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[] {
+            Event.class
+        };
+    }
+
+    private Event _event;
+
+    @Override
+    public void afterInit() {
+        _event = doInJPA(entityManager -> {
+            entityManager.persist(new Event());
+
+            Event event = new Event();
+            event.setMac("08:00:2b:01:02:03");
+            entityManager.persist(event);
+
+            return event;
+        });
+    }
+
+    @Test
+    public void testFindById() {
+        Event updatedEvent = doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+
+            event.setMac("08:00:2b:01:02:04");
+
+            return event;
+        });
+
+        assertEquals("08:00:2b:01:02:04", updatedEvent.getMac().getAddress());
+    }
+
+    @Test
+    public void testJPQLQuery() {
+        doInJPA(entityManager -> {
+            Event event = entityManager.createQuery(
+                "select e " +
+                "from Event e " +
+                "where " +
+                "   mac is not null", Event.class)
+            .getSingleResult();
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+        });
+    }
+
+    @Test
+    public void testNativeQuery() {
+        doInJPA(entityManager -> {
+            Event event = (Event) entityManager.createNativeQuery(
+                "SELECT e.* " +
+                "FROM event e " +
+                "WHERE " +
+                "   e.mac = CAST(:mac AS macaddr)", Event.class)
+            .setParameter("mac", "08:00:2b:01:02:03")
+            .getSingleResult();
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+        });
+    }
+
+    @Test
+    public void testJDBCQuery() {
+        doInJPA(entityManager -> {
+            Session session = entityManager.unwrap(Session.class);
+            session.doWork(connection -> {
+                try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT * " +
+                    "FROM event e " +
+                    "WHERE " +
+                    "   e.mac = ?::macaddr"
+                )) {
+                    ps.setObject(1, "08:00:2b:01:02:03");
+                    ResultSet rs = ps.executeQuery();
+                    while (rs.next()) {
+                        String mac = rs.getString(2);
+                        assertEquals("08:00:2b:01:02:03", mac);
+                    }
+                }
+            });
+        });
+    }
+
+    @Entity(name = "Event")
+    @Table(name = "event")
+    public static class Event {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Type(PostgreSQLMacAddressType.class)
+        @Column(name = "mac", columnDefinition = "macaddr")
+        private MacAddress mac;
+
+        public Long getId() {
+            return id;
+        }
+
+        public MacAddress getMac() {
+            return mac;
+        }
+
+        public void setMac(String address) {
+            this.mac = new MacAddress(address);
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -5,6 +5,7 @@ import io.hypersistence.utils.common.StringUtils;
 import io.hypersistence.utils.hibernate.type.basic.Iso8601MonthType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLHStoreType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLInetType;
+import io.hypersistence.utils.hibernate.type.basic.PostgreSQLMacAddressType;
 import io.hypersistence.utils.hibernate.type.interval.OracleIntervalDayToSecondType;
 import io.hypersistence.utils.hibernate.type.interval.PostgreSQLPeriodType;
 import io.hypersistence.utils.hibernate.type.json.JsonNodeStringType;
@@ -95,6 +96,7 @@ public class HibernateTypesContributor implements TypeContributor {
             /* Specific-types */
             contributeType(typeContributions, PostgreSQLHStoreType.INSTANCE, typeFilter);
             contributeType(typeContributions, PostgreSQLInetType.INSTANCE, typeFilter);
+            contributeType(typeContributions, PostgreSQLMacAddressType.INSTANCE, typeFilter);
             contributeType(typeContributions, PostgreSQLRangeType.INSTANCE, typeFilter);
 
             if(ReflectionUtils.getClassOrNull("com.google.common.collect.Range") != null) {

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/basic/MacAddress.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/basic/MacAddress.java
@@ -1,0 +1,39 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * The {@link MacAddress} object type is used to represent a PostgreSQL {@code macaddr} (MAC address) column.
+ * <p>
+ * The value is stored using the canonical representation returned by PostgreSQL (e.g. {@code 08:00:2b:01:02:03}).
+ */
+public class MacAddress implements Serializable {
+
+    private final String address;
+
+    public MacAddress(String address) {
+        this.address = address;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return Objects.equals(address, MacAddress.class.cast(o).address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
+    }
+
+    @Override
+    public String toString() {
+        return address;
+    }
+}

--- a/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressType.java
+++ b/hypersistence-utils-hibernate-71/src/main/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressType.java
@@ -1,0 +1,56 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import io.hypersistence.utils.hibernate.type.ImmutableType;
+import io.hypersistence.utils.hibernate.type.util.Configuration;
+import io.hypersistence.utils.common.ReflectionUtils;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link MacAddress} object type to a PostgreSQL {@code macaddr} column type.
+ */
+public class PostgreSQLMacAddressType extends ImmutableType<MacAddress> {
+
+    public static final PostgreSQLMacAddressType INSTANCE = new PostgreSQLMacAddressType();
+
+    public PostgreSQLMacAddressType() {
+        super(MacAddress.class);
+    }
+
+    public PostgreSQLMacAddressType(org.hibernate.type.spi.TypeBootstrapContext typeBootstrapContext) {
+        super(MacAddress.class, new Configuration(typeBootstrapContext.getConfigurationSettings()));
+    }
+
+    @Override
+    public int getSqlType() {
+        return Types.OTHER;
+    }
+
+    @Override
+    public MacAddress get(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        String macAddress = rs.getString(position);
+        return (macAddress != null) ? new MacAddress(macAddress) : null;
+    }
+
+    @Override
+    public void set(PreparedStatement st, MacAddress value, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", "macaddr");
+            ReflectionUtils.invokeSetter(holder, "value", value.getAddress());
+            st.setObject(index, holder);
+        }
+    }
+
+    @Override
+    public MacAddress fromStringValue(CharSequence sequence) throws HibernateException {
+        return sequence != null ? new MacAddress((String) sequence) : null;
+    }
+}

--- a/hypersistence-utils-hibernate-71/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressTypeTest.java
+++ b/hypersistence-utils-hibernate-71/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressTypeTest.java
@@ -1,0 +1,128 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgreSQLMacAddressTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[] {
+            Event.class
+        };
+    }
+
+    private Event _event;
+
+    @Override
+    public void afterInit() {
+        _event = doInJPA(entityManager -> {
+            entityManager.persist(new Event());
+
+            Event event = new Event();
+            event.setMac("08:00:2b:01:02:03");
+            entityManager.persist(event);
+
+            return event;
+        });
+    }
+
+    @Test
+    public void testFindById() {
+        Event updatedEvent = doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+
+            event.setMac("08:00:2b:01:02:04");
+
+            return event;
+        });
+
+        assertEquals("08:00:2b:01:02:04", updatedEvent.getMac().getAddress());
+    }
+
+    @Test
+    public void testJPQLQuery() {
+        doInJPA(entityManager -> {
+            Event event = entityManager.createQuery(
+                "select e " +
+                "from Event e " +
+                "where " +
+                "   mac is not null", Event.class)
+            .getSingleResult();
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+        });
+    }
+
+    @Test
+    public void testNativeQuery() {
+        doInJPA(entityManager -> {
+            Event event = (Event) entityManager.createNativeQuery(
+                "SELECT e.* " +
+                "FROM event e " +
+                "WHERE " +
+                "   e.mac = CAST(:mac AS macaddr)", Event.class)
+            .setParameter("mac", "08:00:2b:01:02:03")
+            .getSingleResult();
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+        });
+    }
+
+    @Test
+    public void testJDBCQuery() {
+        doInJPA(entityManager -> {
+            Session session = entityManager.unwrap(Session.class);
+            session.doWork(connection -> {
+                try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT * " +
+                    "FROM event e " +
+                    "WHERE " +
+                    "   e.mac = ?::macaddr"
+                )) {
+                    ps.setObject(1, "08:00:2b:01:02:03");
+                    ResultSet rs = ps.executeQuery();
+                    while (rs.next()) {
+                        String mac = rs.getString(2);
+                        assertEquals("08:00:2b:01:02:03", mac);
+                    }
+                }
+            });
+        });
+    }
+
+    @Entity(name = "Event")
+    @Table(name = "event")
+    public static class Event {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Type(PostgreSQLMacAddressType.class)
+        @Column(name = "mac", columnDefinition = "macaddr")
+        private MacAddress mac;
+
+        public Long getId() {
+            return id;
+        }
+
+        public MacAddress getMac() {
+            return mac;
+        }
+
+        public void setMac(String address) {
+            this.mac = new MacAddress(address);
+        }
+    }
+}

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/HibernateTypesContributor.java
@@ -5,6 +5,7 @@ import io.hypersistence.utils.common.StringUtils;
 import io.hypersistence.utils.hibernate.type.basic.Iso8601MonthType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLHStoreType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLInetType;
+import io.hypersistence.utils.hibernate.type.basic.PostgreSQLMacAddressType;
 import io.hypersistence.utils.hibernate.type.interval.OracleIntervalDayToSecondType;
 import io.hypersistence.utils.hibernate.type.interval.PostgreSQLPeriodType;
 import io.hypersistence.utils.hibernate.type.json.JsonNodeStringType;
@@ -95,6 +96,7 @@ public class HibernateTypesContributor implements TypeContributor {
             /* Specific-types */
             contributeType(typeContributions, PostgreSQLHStoreType.INSTANCE, typeFilter);
             contributeType(typeContributions, PostgreSQLInetType.INSTANCE, typeFilter);
+            contributeType(typeContributions, PostgreSQLMacAddressType.INSTANCE, typeFilter);
             contributeType(typeContributions, PostgreSQLRangeType.INSTANCE, typeFilter);
 
             if(ReflectionUtils.getClassOrNull("com.google.common.collect.Range") != null) {

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/basic/MacAddress.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/basic/MacAddress.java
@@ -1,0 +1,39 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * The {@link MacAddress} object type is used to represent a PostgreSQL {@code macaddr} (MAC address) column.
+ * <p>
+ * The value is stored using the canonical representation returned by PostgreSQL (e.g. {@code 08:00:2b:01:02:03}).
+ */
+public class MacAddress implements Serializable {
+
+    private final String address;
+
+    public MacAddress(String address) {
+        this.address = address;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return Objects.equals(address, MacAddress.class.cast(o).address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address);
+    }
+
+    @Override
+    public String toString() {
+        return address;
+    }
+}

--- a/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressType.java
+++ b/hypersistence-utils-hibernate-73/src/main/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressType.java
@@ -1,0 +1,56 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import io.hypersistence.utils.hibernate.type.ImmutableType;
+import io.hypersistence.utils.hibernate.type.util.Configuration;
+import io.hypersistence.utils.common.ReflectionUtils;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Maps a {@link MacAddress} object type to a PostgreSQL {@code macaddr} column type.
+ */
+public class PostgreSQLMacAddressType extends ImmutableType<MacAddress> {
+
+    public static final PostgreSQLMacAddressType INSTANCE = new PostgreSQLMacAddressType();
+
+    public PostgreSQLMacAddressType() {
+        super(MacAddress.class);
+    }
+
+    public PostgreSQLMacAddressType(org.hibernate.type.spi.TypeBootstrapContext typeBootstrapContext) {
+        super(MacAddress.class, new Configuration(typeBootstrapContext.getConfigurationSettings()));
+    }
+
+    @Override
+    public int getSqlType() {
+        return Types.OTHER;
+    }
+
+    @Override
+    public MacAddress get(ResultSet rs, int position, SharedSessionContractImplementor session, Object owner) throws SQLException {
+        String macAddress = rs.getString(position);
+        return (macAddress != null) ? new MacAddress(macAddress) : null;
+    }
+
+    @Override
+    public void set(PreparedStatement st, MacAddress value, int index, SharedSessionContractImplementor session) throws SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            Object holder = ReflectionUtils.newInstance("org.postgresql.util.PGobject");
+            ReflectionUtils.invokeSetter(holder, "type", "macaddr");
+            ReflectionUtils.invokeSetter(holder, "value", value.getAddress());
+            st.setObject(index, holder);
+        }
+    }
+
+    @Override
+    public MacAddress fromStringValue(CharSequence sequence) throws HibernateException {
+        return sequence != null ? new MacAddress((String) sequence) : null;
+    }
+}

--- a/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressTypeTest.java
+++ b/hypersistence-utils-hibernate-73/src/test/java/io/hypersistence/utils/hibernate/type/basic/PostgreSQLMacAddressTypeTest.java
@@ -1,0 +1,128 @@
+package io.hypersistence.utils.hibernate.type.basic;
+
+import io.hypersistence.utils.hibernate.util.AbstractPostgreSQLIntegrationTest;
+import jakarta.persistence.*;
+import org.hibernate.Session;
+import org.hibernate.annotations.Type;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgreSQLMacAddressTypeTest extends AbstractPostgreSQLIntegrationTest {
+
+    @Override
+    protected Class<?>[] entities() {
+        return new Class<?>[] {
+            Event.class
+        };
+    }
+
+    private Event _event;
+
+    @Override
+    public void afterInit() {
+        _event = doInJPA(entityManager -> {
+            entityManager.persist(new Event());
+
+            Event event = new Event();
+            event.setMac("08:00:2b:01:02:03");
+            entityManager.persist(event);
+
+            return event;
+        });
+    }
+
+    @Test
+    public void testFindById() {
+        Event updatedEvent = doInJPA(entityManager -> {
+            Event event = entityManager.find(Event.class, _event.getId());
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+
+            event.setMac("08:00:2b:01:02:04");
+
+            return event;
+        });
+
+        assertEquals("08:00:2b:01:02:04", updatedEvent.getMac().getAddress());
+    }
+
+    @Test
+    public void testJPQLQuery() {
+        doInJPA(entityManager -> {
+            Event event = entityManager.createQuery(
+                "select e " +
+                "from Event e " +
+                "where " +
+                "   mac is not null", Event.class)
+            .getSingleResult();
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+        });
+    }
+
+    @Test
+    public void testNativeQuery() {
+        doInJPA(entityManager -> {
+            Event event = (Event) entityManager.createNativeQuery(
+                "SELECT e.* " +
+                "FROM event e " +
+                "WHERE " +
+                "   e.mac = CAST(:mac AS macaddr)", Event.class)
+            .setParameter("mac", "08:00:2b:01:02:03")
+            .getSingleResult();
+
+            assertEquals("08:00:2b:01:02:03", event.getMac().getAddress());
+        });
+    }
+
+    @Test
+    public void testJDBCQuery() {
+        doInJPA(entityManager -> {
+            Session session = entityManager.unwrap(Session.class);
+            session.doWork(connection -> {
+                try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT * " +
+                    "FROM event e " +
+                    "WHERE " +
+                    "   e.mac = ?::macaddr"
+                )) {
+                    ps.setObject(1, "08:00:2b:01:02:03");
+                    ResultSet rs = ps.executeQuery();
+                    while (rs.next()) {
+                        String mac = rs.getString(2);
+                        assertEquals("08:00:2b:01:02:03", mac);
+                    }
+                }
+            });
+        });
+    }
+
+    @Entity(name = "Event")
+    @Table(name = "event")
+    public static class Event {
+
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        @Type(PostgreSQLMacAddressType.class)
+        @Column(name = "mac", columnDefinition = "macaddr")
+        private MacAddress mac;
+
+        public Long getId() {
+            return id;
+        }
+
+        public MacAddress getMac() {
+            return mac;
+        }
+
+        public void setMac(String address) {
+            this.mac = new MacAddress(address);
+        }
+    }
+}


### PR DESCRIPTION
Closes #858 

There wasn't a mapping for the PostgreSQL `macaddr` column type, so I added one by following how the existing `inet` type is done.

What I added (in the hibernate-63, 71 and 73 modules):
- `MacAddress` – a small value class that holds the address string
- `PostgreSQLMacAddressType` – an `ImmutableType<MacAddress>` that reads/writes the column using a PGobject of type "macaddr"
- registered the new type in `HibernateTypesContributor` next to `PostgreSQLInetType`

I named the type `PostgreSQLMacAddressType` to follow the Hibernate naming conventions, as suggested in the issue.

Testing:
- Added `PostgreSQLMacAddressTypeTest`, based on the existing `PostgreSQLInetTypeTest`
- It covers find, JPQL, native query and a raw JDBC check
- All tests pass on Testcontainers PostgreSQL in all three modules